### PR TITLE
add backend agents and chat api

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,0 +1,63 @@
+"""FastAPI dependencies."""
+
+from functools import lru_cache
+from typing import Dict
+import os
+import logging
+
+from app.core.agents.graph.workflow import ConversationWorkflow
+from app.core.agents.crew.crew import AnalyticsCrew
+
+logger = logging.getLogger(__name__)
+
+
+class ApplicationState:
+    """Singleton application state."""
+
+    _instance = None
+    _conversation_workflows: Dict[str, ConversationWorkflow] = {}
+    _analytics_crew: AnalyticsCrew = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            logger.info("🏗️  [AppState] Created new ApplicationState singleton")
+        return cls._instance
+
+    def get_conversation_workflow(self, campaigner_id: int, thread_id: str = "default") -> ConversationWorkflow:
+        """Get or create conversation workflow for thread."""
+        if thread_id not in self._conversation_workflows:
+            logger.info(f"🆕 [AppState] Creating new workflow for thread: {thread_id[:8]}... | Campaigner: {campaigner_id}")
+            self._conversation_workflows[thread_id] = ConversationWorkflow(campaigner_id=campaigner_id)
+        else:
+            logger.debug(f"♻️  [AppState] Reusing existing workflow for thread: {thread_id[:8]}...")
+        return self._conversation_workflows[thread_id]
+
+    def get_analytics_crew(self) -> AnalyticsCrew:
+        """Get or create analytics crew."""
+        if self._analytics_crew is None:
+            logger.info("🆕 [AppState] Creating new AnalyticsCrew instance")
+            self._analytics_crew = AnalyticsCrew()
+        else:
+            logger.debug("♻️  [AppState] Reusing existing AnalyticsCrew instance")
+        return self._analytics_crew
+
+    def reset_thread(self, thread_id: str):
+        """Reset a conversation thread."""
+        if thread_id in self._conversation_workflows:
+            logger.info(f"🔄 [AppState] Resetting thread: {thread_id[:8]}...")
+            del self._conversation_workflows[thread_id]
+        else:
+            logger.debug(f"⚠️  [AppState] Thread {thread_id[:8]}... not found, nothing to reset")
+
+    def get_all_threads(self) -> Dict[str, ConversationWorkflow]:
+        """Get all conversation threads."""
+        logger.debug(f"📋 [AppState] Returning {len(self._conversation_workflows)} threads")
+        return self._conversation_workflows
+
+
+@lru_cache()
+def get_app_state() -> ApplicationState:
+    """Get application state singleton."""
+    return ApplicationState()
+

--- a/app/api/schemas/chat.py
+++ b/app/api/schemas/chat.py
@@ -1,0 +1,188 @@
+"""API request/response models."""
+
+from typing import List, Dict, Any, Optional
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+
+# ===== Chat/Conversation Models =====
+
+class Message(BaseModel):
+    """Chat message."""
+    role: str = Field(..., description="Message role: 'user' or 'assistant'")
+    content: str = Field(..., description="Message content")
+
+
+class ChatRequest(BaseModel):
+    """Chat request."""
+    message: str = Field(..., description="User message", min_length=1)
+    thread_id: Optional[str] = Field(None, description="Conversation thread ID")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "message": "Show me Facebook Ads performance for last month",
+                "thread_id": "user-123",
+            }
+        }
+
+
+class ChatResponse(BaseModel):
+    """Chat response."""
+    message: str = Field(..., description="Assistant's response")
+    thread_id: str = Field(..., description="Conversation thread ID")
+    needs_clarification: bool = Field(..., description="Whether user clarification is needed")
+    ready_for_analysis: bool = Field(..., description="Whether ready to run analytics")
+    intent: Optional[Dict[str, Any]] = Field(None, description="Extracted user intent")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "message": "I'll analyze Facebook Ads for last month. What metrics would you like to see?",
+                "thread_id": "user-123",
+                "needs_clarification": True,
+                "ready_for_analysis": False,
+                "intent": {
+                    "platforms": ["facebook"],
+                    "date_range_start": "2025-09-01",
+                    "date_range_end": "2025-09-30"
+                }
+            }
+        }
+
+
+# ===== Analytics Models =====
+
+class AnalyticsRequest(BaseModel):
+    """Analytics request."""
+    platforms: List[str] = Field(..., description="Platforms to analyze: 'facebook', 'google'")
+    metrics: List[str] = Field(..., description="Metrics to retrieve")
+    date_range_start: str = Field(..., description="Start date (YYYY-MM-DD)")
+    date_range_end: str = Field(..., description="End date (YYYY-MM-DD)")
+    comparison_period: bool = Field(False, description="Compare with previous period")
+    specific_campaigns: Optional[List[str]] = Field(None, description="Specific campaign IDs")
+    thread_id: Optional[str] = Field(None, description="Associated conversation thread")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "platforms": ["facebook", "google"],
+                "metrics": ["traffic", "conversions", "ad_spend"],
+                "date_range_start": "2025-09-01",
+                "date_range_end": "2025-09-30",
+                "comparison_period": True,
+                "specific_campaigns": ["campaign_123"]
+            }
+        }
+
+
+class InsightModel(BaseModel):
+    """Analytics insight."""
+    title: str
+    description: str
+    severity: str = Field(default="info", description="info, warning, critical, positive")
+    related_metrics: List[str] = Field(default_factory=list)
+    recommendation: Optional[str] = None
+    confidence: float = Field(default=0.8, ge=0.0, le=1.0)
+
+
+class AnalyticsResponse(BaseModel):
+    """Analytics response."""
+    success: bool
+    platforms: List[str]
+    summary: str = Field(..., description="Executive summary")
+    insights: List[InsightModel] = Field(default_factory=list)
+    recommendations: List[str] = Field(default_factory=list)
+    data: Optional[Dict[str, Any]] = Field(None, description="Raw analytics data")
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    thread_id: Optional[str] = None
+    error: Optional[str] = None
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "success": True,
+                "platforms": ["facebook", "google"],
+                "summary": "Overall performance improved by 15% compared to previous period.",
+                "insights": [
+                    {
+                        "title": "Traffic Spike",
+                        "description": "30% increase in organic traffic",
+                        "severity": "positive",
+                        "related_metrics": ["traffic", "sessions"],
+                        "confidence": 0.9
+                    }
+                ],
+                "recommendations": [
+                    "Increase budget for top-performing campaigns",
+                    "Test new audience segments"
+                ],
+                "generated_at": "2025-10-19T22:00:00Z"
+            }
+        }
+
+
+# ===== Conversation State Models =====
+
+class ConversationThread(BaseModel):
+    """Conversation thread info."""
+    thread_id: str
+    created_at: datetime
+    last_message_at: datetime
+    message_count: int
+    intent_complete: bool
+    platforms: List[str] = Field(default_factory=list)
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "thread_id": "user-123",
+                "created_at": "2025-10-19T20:00:00Z",
+                "last_message_at": "2025-10-19T20:05:00Z",
+                "message_count": 4,
+                "intent_complete": True,
+                "platforms": ["facebook"]
+            }
+        }
+
+
+class ThreadListResponse(BaseModel):
+    """List of conversation threads."""
+    threads: List[ConversationThread]
+    total: int
+
+
+# ===== Health & Info Models =====
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+    status: str
+    version: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    services: Dict[str, str] = Field(default_factory=dict)
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "status": "healthy",
+                "version": "0.1.0",
+                "timestamp": "2025-10-19T22:00:00Z",
+                "services": {
+                    "langgraph": "ok",
+                    "crewai": "ok",
+                    "llm": "ok"
+                }
+            }
+        }
+
+
+class InfoResponse(BaseModel):
+    """API information."""
+    name: str = "Sato Marketing Analytics API"
+    version: str = "0.1.0"
+    description: str = "AI-powered marketing analytics combining LangGraph and CrewAI"
+    features: List[str] = Field(default_factory=list)
+    supported_platforms: List[str] = Field(default_factory=lambda: ["facebook", "google"])
+    supported_metrics: List[str] = Field(default_factory=lambda: [
+        "traffic", "conversions", "ad_spend", "roi", "engagement", "demographics"
+    ])

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -27,7 +27,7 @@ from .routes import (
     database_management,
     customer_data
 )
-
+from app.api.v1.routes.chat import router as chat_router
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -54,5 +54,6 @@ api_router.include_router(campaigners.router, tags=["campaigners"])
 api_router.include_router(customers.router, tags=["customers"])
 api_router.include_router(database_management.router, tags=["database-management"])
 api_router.include_router(customer_data.router, tags=["customer-data"])
+api_router.include_router(chat_router, tags=["chat"])
 
 __all__ = ["api_router"]

--- a/app/api/v1/routes/chat.py
+++ b/app/api/v1/routes/chat.py
@@ -1,0 +1,249 @@
+"""Chat/conversation endpoints."""
+
+from fastapi import APIRouter, HTTPException, Depends
+from fastapi.responses import StreamingResponse
+from typing import List
+from datetime import datetime
+import uuid
+import json
+import asyncio
+import logging
+
+from app.api.schemas.chat import (
+    ChatRequest,
+    ChatResponse,
+    ConversationThread,
+    ThreadListResponse
+)
+from app.api.dependencies import get_app_state, ApplicationState
+from app.core.auth import get_current_user
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+logger = logging.getLogger(__name__)
+
+
+@router.post("", response_model=ChatResponse)
+async def chat(
+    request: ChatRequest,
+    app_state: ApplicationState = Depends(get_app_state),
+    current_user = Depends(get_current_user)
+):
+    """
+    Send a message to the conversation agent.
+
+    The agent will extract intent from your message and ask clarifying questions
+    until it has all the information needed to run analytics.
+
+    Requires authentication via JWT token.
+    """
+    try:
+        # Generate thread ID if not provided
+        thread_id = request.thread_id or str(uuid.uuid4())
+        logger.info(f"💬 [Chat] Thread: {thread_id[:8]}... | Message: '{request.message[:50]}...'")
+
+        # Get conversation workflow for this thread (with campaigner_id)
+        logger.debug(f"📋 [Chat] Getting workflow for thread: {thread_id} | Request: {request}")
+        workflow = app_state.get_conversation_workflow(current_user.id, thread_id)
+
+        # Process message
+        logger.debug(f"🔄 [Chat] Processing message through workflow...")
+        result = workflow.process_message(request.message)
+        logger.debug(f"✅ [Chat] Workflow processed. Result keys: {list(result.keys())}")
+
+        # Extract response message
+        messages = result.get("messages", [])
+        assistant_message = ""
+        if messages:
+            last_message = messages[-1]
+            if hasattr(last_message, "content"):
+                assistant_message = last_message.content
+                logger.debug(f"💭 [Chat] Assistant message: '{assistant_message[:100]}...'")
+
+        # If clarification question exists, use that
+        if result.get("clarification_question"):
+            assistant_message = result["clarification_question"]
+            logger.info(f"❓ [Chat] Clarification needed: '{assistant_message[:100]}...'")
+
+        # Build intent dict
+        intent = {
+            "platforms": result.get("platforms", []),
+            "metrics": result.get("metrics", []),
+            "date_range_start": result.get("date_range_start"),
+            "date_range_end": result.get("date_range_end"),
+            "comparison_period": result.get("comparison_period", False),
+            "specific_campaigns": result.get("specific_campaigns"),
+        }
+
+        needs_clarification = result.get("clarification_needed", False)
+        ready_for_analysis = result.get("ready_for_crew", False)
+
+        logger.info(
+            f"📊 [Chat] State: clarification={needs_clarification}, "
+            f"ready={ready_for_analysis}, "
+            f"platforms={intent.get('platforms', [])}"
+        )
+
+        return ChatResponse(
+            message=assistant_message or "I'm processing your request...",
+            thread_id=thread_id,
+            needs_clarification=needs_clarification,
+            ready_for_analysis=ready_for_analysis,
+            intent=intent if any(intent.values()) else None
+        )
+
+    except Exception as e:
+        logger.error(f"❌ [Chat] Error processing chat: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Chat processing failed: {str(e)}")
+
+
+@router.post("/stream")
+async def stream_chat(
+    request: ChatRequest,
+    app_state: ApplicationState = Depends(get_app_state),
+    current_user = Depends(get_current_user)
+):
+    """
+    Stream chat response in real-time (SSE format).
+
+    Returns Server-Sent Events with the response being generated.
+
+    Requires authentication via JWT token.
+    """
+
+    async def generate():
+        try:
+            # Generate thread ID if not provided
+            thread_id = request.thread_id or str(uuid.uuid4())
+            logger.info(f"📡 [Stream] Thread: {thread_id[:8]}... | Message: '{request.message[:50]}...'")
+
+            # Get conversation workflow for this thread (with campaigner_id)
+            workflow = app_state.get_conversation_workflow(current_user.id, thread_id)
+
+            # Process message
+            logger.debug(f"🔄 [Stream] Processing message...")
+            result = workflow.process_message(request.message)
+
+            # Extract response message
+            messages = result.get("messages", [])
+            assistant_message = ""
+            if messages:
+                last_message = messages[-1]
+                if hasattr(last_message, "content"):
+                    assistant_message = last_message.content
+
+            # If clarification question exists, use that
+            if result.get("clarification_question"):
+                assistant_message = result["clarification_question"]
+
+            logger.info(f"📤 [Stream] Streaming {len(assistant_message.split())} words")
+
+            # Stream the message word by word
+            words = assistant_message.split()
+            for i, word in enumerate(words):
+                chunk = word + (" " if i < len(words) - 1 else "")
+                yield f"data: {json.dumps({'chunk': chunk})}\n\n"
+                await asyncio.sleep(0.05)  # Simulate streaming
+
+            # Send metadata at the end
+            metadata = {
+                "thread_id": thread_id,
+                "needs_clarification": result.get("clarification_needed", False),
+                "ready_for_analysis": result.get("ready_for_crew", False),
+                "intent": {
+                    "platforms": result.get("platforms", []),
+                    "metrics": result.get("metrics", []),
+                    "date_range_start": result.get("date_range_start"),
+                    "date_range_end": result.get("date_range_end"),
+                }
+            }
+            logger.info(f"✅ [Stream] Completed. Ready: {metadata['ready_for_analysis']}")
+            yield f"data: {json.dumps({'metadata': metadata})}\n\n"
+            yield "data: [DONE]\n\n"
+
+        except Exception as e:
+            logger.error(f"❌ [Stream] Error: {str(e)}", exc_info=True)
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        }
+    )
+
+
+@router.get("/threads", response_model=ThreadListResponse)
+async def list_threads(
+    app_state: ApplicationState = Depends(get_app_state)
+):
+    """List all conversation threads."""
+    threads = []
+    all_workflows = app_state.get_all_threads()
+
+    for thread_id, workflow in all_workflows.items():
+        # Get state from workflow if available
+        state = workflow.conversation_state if hasattr(workflow, 'conversation_state') else {}
+        messages = state.get("messages", [])
+
+        thread = ConversationThread(
+            thread_id=thread_id,
+            created_at=datetime.now(),  # Fixed deprecation
+            last_message_at=datetime.now(),
+            message_count=len(messages),
+            intent_complete=state.get("is_complete", False),
+            platforms=state.get("platforms", [])
+        )
+        threads.append(thread)
+
+    return ThreadListResponse(
+        threads=threads,
+        total=len(threads)
+    )
+
+
+@router.delete("/threads/{thread_id}")
+async def delete_thread(
+    thread_id: str,
+    app_state: ApplicationState = Depends(get_app_state)
+):
+    """Delete/reset a conversation thread."""
+    logger.info(f"🗑️  [Threads] Deleting thread: {thread_id[:8]}...")
+    app_state.reset_thread(thread_id)
+    return {"message": f"Thread {thread_id} deleted successfully"}
+
+
+@router.get("/threads/{thread_id}")
+async def get_thread(
+    thread_id: str,
+    app_state: ApplicationState = Depends(get_app_state)
+):
+    """Get conversation thread details."""
+    workflows = app_state.get_all_threads()
+
+    if thread_id not in workflows:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    workflow = workflows[thread_id]
+    state = workflow.conversation_state if hasattr(workflow, 'conversation_state') else {}
+
+    return {
+        "thread_id": thread_id,
+        "state": {
+            "platforms": state.get("platforms", []),
+            "metrics": state.get("metrics", []),
+            "date_range_start": state.get("date_range_start"),
+            "date_range_end": state.get("date_range_end"),
+            "is_complete": state.get("is_complete", False),
+            "ready_for_crew": state.get("ready_for_crew", False),
+            "crew_task": state.get("crew_task")
+        },
+        "messages": [
+            {
+                "role": msg.type if hasattr(msg, "type") else "unknown",
+                "content": msg.content if hasattr(msg, "content") else str(msg)
+            }
+            for msg in state.get("messages", [])
+        ]
+    }

--- a/app/core/agents/crew/__init__.py
+++ b/app/core/agents/crew/__init__.py
@@ -1,0 +1,5 @@
+"""CrewAI analytics crew."""
+
+from .crew import AnalyticsCrew
+
+__all__ = ["AnalyticsCrew"]

--- a/app/core/agents/crew/agents.py
+++ b/app/core/agents/crew/agents.py
@@ -1,0 +1,78 @@
+"""Agent definitions for the analytics crew."""
+
+from crewai import Agent
+from langchain_openai import ChatOpenAI
+from typing import List, Optional
+import os
+
+
+class AnalyticsAgents:
+    """Factory for creating analytics crew agents."""
+
+    def __init__(self, llm: Optional[ChatOpenAI] = None):
+        self.llm = llm or ChatOpenAI(
+            model="gpt-4o",
+            temperature=0.3,
+            api_key=os.getenv("OPENAI_API_KEY")
+        )
+
+    def create_master_agent(self) -> Agent:
+        """Create the master orchestrator agent."""
+
+        return Agent(
+            role="Analytics Master Orchestrator",
+            goal="Coordinate data collection from specialists and synthesize comprehensive insights",
+            backstory="""You are an expert data analyst with 15+ years of experience in
+            digital marketing analytics. You excel at synthesizing data from multiple
+            sources, identifying patterns, and providing actionable recommendations.
+            You coordinate with platform specialists to gather data and create unified
+            insights that help businesses make data-driven decisions.""",
+            reasoning=True,
+            max_reasoning_attempts=None,
+            inject_date=True,
+            verbose=True,
+            allow_delegation=True, #TODO: validate if this should be True or False
+            llm=self.llm,
+            max_iter=5
+        )
+
+    def create_facebook_specialist(self, tools: List) -> Agent:
+        """Create the Facebook Ads specialist agent."""
+
+        return Agent(
+            role="Facebook Ads Specialist",
+            goal="Extract, analyze, and provide insights from Facebook Ads data",
+            backstory="""You are a Facebook Ads expert with deep knowledge of the
+            Facebook Ads platform, campaign optimization, and audience targeting.
+            You understand metrics like CPM, CPC, ROAS, and can identify trends in
+            campaign performance. You use the Facebook Ads MCP server to fetch real-time
+            data and provide detailed analysis of ad performance, audience behavior,
+            and optimization opportunities.""",
+            verbose=True,
+            inject_date=True,
+            allow_delegation=False,
+            tools=tools,
+            llm=self.llm,
+            max_iter=5
+        )
+
+    def create_google_specialist(self, tools: List) -> Agent:
+        """Create the Google Analytics specialist agent."""
+
+        return Agent(
+            role="Google Analytics Specialist",
+            goal="Extract, analyze, and provide insights from Google Analytics data",
+            backstory="""You are a Google Analytics expert with comprehensive knowledge
+            of GA4, user behavior analysis, and conversion tracking. You understand
+            metrics like sessions, bounce rate, conversion rate, and user journeys.
+            You use the Google Analytics MCP server to fetch real-time data and provide
+            detailed analysis of website traffic, user behavior, conversion funnels,
+            and content performance. You excel at identifying opportunities for
+            improving user experience and conversion rates.""",
+            verbose=True,
+            inject_date=True,
+            allow_delegation=False,
+            tools=tools,
+            llm=self.llm,
+            max_iter=5
+        )

--- a/app/core/agents/crew/crew.py
+++ b/app/core/agents/crew/crew.py
@@ -1,0 +1,140 @@
+"""Main CrewAI crew orchestration."""
+
+from crewai import Crew, Process
+from typing import Dict, Any, List, Optional
+from langchain_openai import ChatOpenAI
+import os
+
+from .agents import AnalyticsAgents
+from .tasks import AnalyticsTasks
+from ..mcp_clients.facebook_client import FacebookMCPClient
+from ..mcp_clients.google_client import GoogleMCPClient
+
+
+class AnalyticsCrew:
+    """Analytics crew for processing marketing data requests."""
+
+    def __init__(self):
+        # Initialize LLM
+        self.llm = ChatOpenAI(
+            model="gpt-4o",
+            temperature=0.3,
+            api_key=os.getenv("OPENAI_API_KEY")
+        )
+
+        # Initialize agent factory
+        self.agents_factory = AnalyticsAgents(self.llm)
+
+        # Initialize tasks factory
+        self.tasks_factory = AnalyticsTasks()
+
+        # Initialize MCP clients
+        self.facebook_client: Optional[FacebookMCPClient] = None
+        self.google_client: Optional[GoogleMCPClient] = None
+
+    def _initialize_mcp_clients(self, platforms: List[str]):
+        """Initialize MCP clients for required platforms."""
+
+        if "facebook" in platforms or "both" in platforms:
+            if not self.facebook_client:
+                self.facebook_client = FacebookMCPClient()
+
+        if "google" in platforms or "both" in platforms:
+            if not self.google_client:
+                self.google_client = GoogleMCPClient()
+
+    def _get_facebook_tools(self) -> List:
+        """Get Facebook MCP tools."""
+        if not self.facebook_client:
+            return []
+        return self.facebook_client.get_tools()
+
+    def _get_google_tools(self) -> List:
+        """Get Google Analytics MCP tools."""
+        if not self.google_client:
+            return []
+        return self.google_client.get_tools()
+
+    def execute(self, task_details: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the analytics crew with the given task details."""
+
+        platforms = task_details.get("platforms", [])
+
+        # Initialize MCP clients
+        self._initialize_mcp_clients(platforms)
+
+        # Create agents
+        master_agent = self.agents_factory.create_master_agent()
+
+        agents = [master_agent]
+        tasks = []
+        specialist_tasks = []
+
+        # Create Facebook specialist if needed
+        if "facebook" in platforms or "both" in platforms:
+            facebook_tools = self._get_facebook_tools()
+            facebook_agent = self.agents_factory.create_facebook_specialist(
+                tools=facebook_tools
+            )
+            facebook_task = self.tasks_factory.create_facebook_analysis_task(
+                agent=facebook_agent,
+                task_details=task_details
+            )
+            agents.append(facebook_agent)
+            tasks.append(facebook_task)
+            specialist_tasks.append(facebook_task)
+
+        # Create Google specialist if needed
+        if "google" in platforms or "both" in platforms:
+            google_tools = self._get_google_tools()
+            google_agent = self.agents_factory.create_google_specialist(
+                tools=google_tools
+            )
+            google_task = self.tasks_factory.create_google_analysis_task(
+                agent=google_agent,
+                task_details=task_details
+            )
+            agents.append(google_agent)
+            tasks.append(google_task)
+            specialist_tasks.append(google_task)
+
+        # Create synthesis task for master agent
+        synthesis_task = self.tasks_factory.create_synthesis_task(
+            agent=master_agent,
+            task_details=task_details,
+            context=specialist_tasks  # Master agent gets specialist outputs
+        )
+        tasks.append(synthesis_task)
+
+        # Create and run crew
+        crew = Crew(
+            agents=agents,
+            tasks=tasks,
+            process=Process.sequential,  # Sequential to ensure specialists run first #TODO: validate if this should be sequential or hierarchical
+            verbose=True
+        )
+
+        try:
+            result = crew.kickoff()
+
+            return {
+                "success": True,
+                "result": result,
+                "platforms": platforms,
+                "task_details": task_details
+            }
+
+        except Exception as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "platforms": platforms,
+                "task_details": task_details
+            }
+
+        finally:
+            # Cleanup MCP clients
+            if self.facebook_client:
+                self.facebook_client.close()
+            if self.google_client:
+                self.google_client.close()

--- a/app/core/agents/crew/tasks.py
+++ b/app/core/agents/crew/tasks.py
@@ -1,0 +1,148 @@
+"""Task definitions for the analytics crew."""
+
+from crewai import Task, Agent
+from typing import Dict, Any, List
+
+
+class AnalyticsTasks:
+    """Factory for creating analytics crew tasks."""
+
+    @staticmethod
+    def create_facebook_analysis_task(
+        agent: Agent,
+        task_details: Dict[str, Any]
+    ) -> Task:
+        """Create a Facebook Ads analysis task."""
+
+        metrics = ", ".join(task_details.get("metrics", []))
+        date_range = task_details.get("date_range", {})
+        campaigns = task_details.get("specific_campaigns")
+
+        campaign_filter = ""
+        if campaigns:
+            campaign_filter = f"\nFocus on these specific campaigns: {', '.join(campaigns)}"
+
+        description = f"""Analyze Facebook Ads data for the following:
+
+Time Period: {date_range.get('start')} to {date_range.get('end')}
+Metrics: {metrics}{campaign_filter}
+
+Your tasks:
+1. Fetch the relevant data from Facebook Ads using the MCP tools
+2. Calculate key performance indicators
+3. Identify trends and patterns in the data
+4. Compare performance across campaigns (if applicable)
+5. Identify top-performing and under-performing campaigns
+6. Provide specific insights about audience engagement
+7. Highlight any anomalies or significant changes
+
+Deliver a structured analysis with:
+- Key metrics summary
+- Performance trends
+- Actionable insights (at least 3)
+- Specific recommendations for optimization
+"""
+
+        expected_output = """A comprehensive Facebook Ads analysis including:
+- Metrics summary (impressions, clicks, conversions, spend, ROAS)
+- Campaign performance comparison
+- Audience insights
+- 3-5 actionable insights with recommendations
+- Data formatted as JSON with structured insights"""
+
+        return Task(
+            description=description,
+            expected_output=expected_output,
+            agent=agent
+        )
+
+    @staticmethod
+    def create_google_analysis_task(
+        agent: Agent,
+        task_details: Dict[str, Any]
+    ) -> Task:
+        """Create a Google Analytics analysis task."""
+
+        metrics = ", ".join(task_details.get("metrics", []))
+        date_range = task_details.get("date_range", {})
+
+        description = f"""Analyze Google Analytics data for the following:
+
+Time Period: {date_range.get('start')} to {date_range.get('end')}
+Metrics: {metrics}
+
+Your tasks:
+1. Fetch the relevant data from Google Analytics using the MCP tools
+2. Calculate key performance indicators
+3. Analyze user behavior and traffic patterns
+4. Examine conversion funnels and drop-off points
+5. Identify top traffic sources and landing pages
+6. Analyze user demographics and device usage
+7. Highlight any significant changes or trends
+
+Deliver a structured analysis with:
+- Key metrics summary
+- Traffic and behavior trends
+- Conversion funnel analysis
+- Actionable insights (at least 3)
+- Specific recommendations for optimization
+"""
+
+        expected_output = """A comprehensive Google Analytics analysis including:
+- Metrics summary (sessions, users, bounce rate, conversions)
+- Traffic source breakdown
+- User behavior insights
+- Conversion funnel analysis
+- 3-5 actionable insights with recommendations
+- Data formatted as JSON with structured insights"""
+
+        return Task(
+            description=description,
+            expected_output=expected_output,
+            agent=agent
+        )
+
+    @staticmethod
+    def create_synthesis_task(
+        agent: Agent,
+        task_details: Dict[str, Any],
+        context: List[Task]
+    ) -> Task:
+        """Create a synthesis task for the master agent."""
+
+        platforms = ", ".join(task_details.get("platforms", []))
+
+        description = f"""Synthesize the analytics data from {platforms} into a unified report.
+
+Your tasks:
+1. Review the analyses from the platform specialists
+2. Identify cross-platform patterns and correlations
+3. Synthesize insights from multiple data sources
+4. Calculate overall marketing performance metrics
+5. Identify opportunities for cross-platform optimization
+6. Prioritize recommendations based on potential impact
+7. Create an executive summary
+
+Deliver a comprehensive report with:
+- Executive summary (2-3 paragraphs)
+- Cross-platform insights
+- Unified recommendations prioritized by impact
+- Overall marketing health assessment
+- Next steps and action items
+"""
+
+        expected_output = """A synthesized analytics report including:
+- Executive summary
+- Key findings from all platforms
+- Cross-platform insights and correlations
+- Prioritized recommendations (top 5)
+- Marketing performance scorecard
+- Detailed action plan
+- Data formatted as structured JSON"""
+
+        return Task(
+            description=description,
+            expected_output=expected_output,
+            agent=agent,
+            context=context  # This task depends on specialist tasks
+        )

--- a/app/core/agents/database/__init__.py
+++ b/app/core/agents/database/__init__.py
@@ -1,0 +1,20 @@
+"""Database utilities for Sato application."""
+
+from .connection import get_db_connection, get_db_engine
+from .tools import (
+    DatabaseTool,
+    get_agency_info,
+    get_customer_info,
+    get_campaigner_info,
+    get_kpi_goals,
+)
+
+__all__ = [
+    "get_db_connection",
+    "get_db_engine",
+    "DatabaseTool",
+    "get_agency_info",
+    "get_customer_info",
+    "get_campaigner_info",
+    "get_kpi_goals",
+]

--- a/app/core/agents/database/connection.py
+++ b/app/core/agents/database/connection.py
@@ -1,0 +1,120 @@
+"""Database connection management."""
+
+import os
+import logging
+from typing import Optional
+from sqlalchemy import create_engine, Engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import NullPool
+
+logger = logging.getLogger(__name__)
+
+
+def get_database_url() -> str:
+    """
+    Get database URL from environment variables.
+
+    Supports both DATABASE_URL (full URL) or individual components.
+
+    Returns:
+        Database connection URL
+
+    Raises:
+        ValueError: If required environment variables are missing
+    """
+    # Option 1: Use DATABASE_URL if provided
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        logger.debug("Using DATABASE_URL from environment")
+        return database_url
+
+    # Option 2: Build from components
+    db_user = os.getenv("DB_USER")
+    db_password = os.getenv("DB_PASSWORD")
+    db_host = os.getenv("DB_HOST")
+    db_port = os.getenv("DB_PORT", "5432")
+    db_name = os.getenv("DB_NAME")
+
+    if not all([db_user, db_password, db_host, db_name]):
+        missing = []
+        if not db_user:
+            missing.append("DB_USER")
+        if not db_password:
+            missing.append("DB_PASSWORD")
+        if not db_host:
+            missing.append("DB_HOST")
+        if not db_name:
+            missing.append("DB_NAME")
+
+        raise ValueError(
+            f"Missing required database environment variables: {', '.join(missing)}. "
+            "Please set DATABASE_URL or (DB_USER, DB_PASSWORD, DB_HOST, DB_NAME)"
+        )
+
+    database_url = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+    logger.debug(f"Built database URL from components: {db_user}@{db_host}:{db_port}/{db_name}")
+
+    return database_url
+
+
+# Global engine instance (singleton)
+_engine: Optional[Engine] = None
+
+
+def get_db_engine(pooling: bool = True) -> Engine:
+    """
+    Get or create the database engine.
+
+    Args:
+        pooling: Whether to use connection pooling (default: True)
+
+    Returns:
+        SQLAlchemy engine instance
+    """
+    global _engine
+
+    if _engine is None:
+        database_url = get_database_url()
+
+        engine_kwargs = {
+            "echo": os.getenv("SQL_ECHO", "false").lower() == "true",
+        }
+
+        # Disable pooling if requested (useful for serverless environments)
+        if not pooling:
+            engine_kwargs["poolclass"] = NullPool
+
+        logger.info(f"🔌 [Database] Creating database engine (pooling={pooling})")
+        _engine = create_engine(database_url, **engine_kwargs)
+        logger.info("✅ [Database] Database engine created successfully")
+
+    return _engine
+
+
+def get_db_connection() -> Session:
+    """
+    Get a database session.
+
+    Returns:
+        SQLAlchemy session instance
+
+    Usage:
+        ```python
+        with get_db_connection() as session:
+            result = session.execute(query)
+        ```
+    """
+    engine = get_db_engine()
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    logger.debug("📊 [Database] Creating new database session")
+    return SessionLocal()
+
+
+def close_db_engine():
+    """Close the global database engine."""
+    global _engine
+    if _engine:
+        logger.info("🔌 [Database] Closing database engine")
+        _engine.dispose()
+        _engine = None

--- a/app/core/agents/database/tools.py
+++ b/app/core/agents/database/tools.py
@@ -1,0 +1,372 @@
+"""Database query tools for agents (read-only access)."""
+
+import logging
+from typing import Dict, Any, List, Optional
+from sqlalchemy import text
+
+from .connection import get_db_connection
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseTool:
+    """Base class for database query tools."""
+
+    def __init__(self, campaigner_id: int):
+        """
+        Initialize database tool.
+
+        Args:
+            campaigner_id: ID of the authenticated campaigner (for authorization)
+        """
+        self.campaigner_id = campaigner_id
+        logger.debug(f"🔧 [DatabaseTool] Initialized for campaigner_id: {campaigner_id}")
+
+    def _execute_query(self, query: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Execute a read-only query and return results.
+
+        Args:
+            query: SQL query string
+            params: Query parameters
+
+        Returns:
+            List of result dictionaries
+        """
+        logger.debug(f"🔍 [DatabaseTool] Executing query with params: {params}")
+
+        try:
+            with get_db_connection() as session:
+                result = session.execute(text(query), params)
+                rows = result.fetchall()
+
+                # Convert to list of dicts
+                results = []
+                if rows:
+                    columns = result.keys()
+                    results = [dict(zip(columns, row)) for row in rows]
+
+                logger.info(f"✅ [DatabaseTool] Query returned {len(results)} rows")
+                return results
+
+        except Exception as e:
+            logger.error(f"❌ [DatabaseTool] Query failed: {str(e)}", exc_info=True)
+            raise
+
+    def get_agency_info(self) -> Optional[Dict[str, Any]]:
+        """
+        Get agency information for the current campaigner.
+
+        Returns:
+            Agency information or None if not found
+        """
+        query = """
+        SELECT a.id, a.name, a.email, a.phone, a.status, a.created_at
+        FROM agencies a
+        JOIN campaigners c ON c.agency_id = a.id
+        WHERE c.id = :campaigner_id
+        """
+
+        logger.info(f"🏢 [DatabaseTool] Getting agency info for campaigner: {self.campaigner_id}")
+        results = self._execute_query(query, {"campaigner_id": self.campaigner_id})
+
+        return results[0] if results else None
+
+    def get_campaigner_info(self) -> Optional[Dict[str, Any]]:
+        """
+        Get campaigner information.
+
+        Returns:
+            Campaigner information or None if not found
+        """
+        query = """
+        SELECT id, email, full_name, phone, role, status, locale, timezone, agency_id
+        FROM campaigners
+        WHERE id = :campaigner_id
+        """
+
+        logger.info(f"👤 [DatabaseTool] Getting campaigner info: {self.campaigner_id}")
+        results = self._execute_query(query, {"campaigner_id": self.campaigner_id})
+
+        return results[0] if results else None
+
+    def get_customers_for_campaigner(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """
+        Get all customers for the campaigner's agency.
+
+        Args:
+            limit: Maximum number of results (default: 100)
+
+        Returns:
+            List of customer records
+        """
+        query = """
+        SELECT c.id, c.full_name, c.status, c.contact_email, c.phone,
+               c.website_url, c.facebook_page_url, c.instagram_page_url,
+               c.assigned_campaigner_id, c.is_active, c.created_at
+        FROM customers c
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE camp.id = :campaigner_id
+          AND c.is_active = true
+        ORDER BY c.created_at DESC
+        LIMIT :limit
+        """
+
+        logger.info(f"👥 [DatabaseTool] Getting customers for campaigner: {self.campaigner_id}")
+        return self._execute_query(query, {"campaigner_id": self.campaigner_id, "limit": limit})
+
+    def get_customer_info(self, customer_id: int) -> Optional[Dict[str, Any]]:
+        """
+        Get detailed customer information.
+
+        Args:
+            customer_id: Customer ID
+
+        Returns:
+            Customer information or None if not found/not authorized
+        """
+        query = """
+        SELECT c.id, c.full_name, c.status, c.contact_email, c.phone, c.address,
+               c.opening_hours, c.website_url, c.facebook_page_url, c.instagram_page_url,
+               c.assigned_campaigner_id, c.is_active, c.created_at, c.updated_at,
+               c.llm_engine_preference
+        FROM customers c
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE c.id = :customer_id
+          AND camp.id = :campaigner_id
+          AND c.is_active = true
+        """
+
+        logger.info(
+            f"🏪 [DatabaseTool] Getting customer info: {customer_id} "
+            f"for campaigner: {self.campaigner_id}"
+        )
+        results = self._execute_query(
+            query, {"customer_id": customer_id, "campaigner_id": self.campaigner_id}
+        )
+
+        return results[0] if results else None
+
+    def get_kpi_goals(
+        self, customer_id: int, limit: int = 50, campaign_status: str = "ACTIVE"
+    ) -> List[Dict[str, Any]]:
+        """
+        Get KPI goals for a specific customer.
+
+        Args:
+            customer_id: Customer ID
+            limit: Maximum number of results (default: 50)
+            campaign_status: Filter by campaign status (default: "ACTIVE")
+
+        Returns:
+            List of KPI goal records
+        """
+        query = """
+        SELECT kg.id, kg.campaign_id, kg.campaign_name, kg.campaign_status,
+               kg.ad_group_id, kg.ad_group_name, kg.ad_id, kg.ad_name,
+               kg.advertising_channel, kg.campaign_objective, kg.daily_budget,
+               kg.target_audience, kg.primary_kpi_1, kg.secondary_kpi_1,
+               kg.secondary_kpi_2, kg.secondary_kpi_3, kg.landing_page,
+               kg.created_at, kg.updated_at
+        FROM kpi_goals kg
+        JOIN customers c ON c.id = kg.customer_id
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE kg.customer_id = :customer_id
+          AND camp.id = :campaigner_id
+          AND kg.campaign_status = :campaign_status
+        ORDER BY kg.updated_at DESC
+        LIMIT :limit
+        """
+
+        logger.info(
+            f"🎯 [DatabaseTool] Getting KPI goals for customer: {customer_id}, "
+            f"status: {campaign_status}"
+        )
+        return self._execute_query(
+            query,
+            {
+                "customer_id": customer_id,
+                "campaigner_id": self.campaigner_id,
+                "campaign_status": campaign_status,
+                "limit": limit,
+            },
+        )
+
+    def get_campaigns_summary(self, customer_id: int) -> Dict[str, Any]:
+        """
+        Get summary statistics of campaigns for a customer.
+
+        Args:
+            customer_id: Customer ID
+
+        Returns:
+            Dictionary with campaign statistics
+        """
+        query = """
+        SELECT
+            COUNT(DISTINCT campaign_id) as total_campaigns,
+            COUNT(DISTINCT CASE WHEN campaign_status = 'ACTIVE' THEN campaign_id END) as active_campaigns,
+            COUNT(DISTINCT CASE WHEN campaign_status = 'PAUSED' THEN campaign_id END) as paused_campaigns,
+            COUNT(DISTINCT ad_group_id) as total_ad_groups,
+            COUNT(DISTINCT ad_id) as total_ads,
+            AVG(daily_budget) as avg_daily_budget,
+            SUM(daily_budget) as total_daily_budget
+        FROM kpi_goals kg
+        JOIN customers c ON c.id = kg.customer_id
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE kg.customer_id = :customer_id
+          AND camp.id = :campaigner_id
+        """
+
+        logger.info(f"📊 [DatabaseTool] Getting campaign summary for customer: {customer_id}")
+        results = self._execute_query(
+            query, {"customer_id": customer_id, "campaigner_id": self.campaigner_id}
+        )
+
+        return results[0] if results else {}
+
+    def search_campaigns(
+        self, customer_id: int, search_term: str, limit: int = 20
+    ) -> List[Dict[str, Any]]:
+        """
+        Search campaigns by name or objective.
+
+        Args:
+            customer_id: Customer ID
+            search_term: Search term for campaign name or objective
+            limit: Maximum number of results (default: 20)
+
+        Returns:
+            List of matching campaign records
+        """
+        query = """
+        SELECT DISTINCT ON (kg.campaign_id)
+            kg.campaign_id, kg.campaign_name, kg.campaign_status,
+            kg.advertising_channel, kg.campaign_objective, kg.daily_budget,
+            kg.created_at
+        FROM kpi_goals kg
+        JOIN customers c ON c.id = kg.customer_id
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE kg.customer_id = :customer_id
+          AND camp.id = :campaigner_id
+          AND (
+              LOWER(kg.campaign_name) LIKE LOWER(:search_term)
+              OR LOWER(kg.campaign_objective) LIKE LOWER(:search_term)
+          )
+        ORDER BY kg.campaign_id, kg.updated_at DESC
+        LIMIT :limit
+        """
+
+        search_pattern = f"%{search_term}%"
+        logger.info(
+            f"🔎 [DatabaseTool] Searching campaigns for customer: {customer_id}, "
+            f"term: '{search_term}'"
+        )
+
+        return self._execute_query(
+            query,
+            {
+                "customer_id": customer_id,
+                "campaigner_id": self.campaigner_id,
+                "search_term": search_pattern,
+                "limit": limit,
+            },
+        )
+
+    def get_all_campaigns_for_campaigner(
+        self, limit: int = 50, campaign_status: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Get all campaigns across all customers for the campaigner's agency.
+
+        Args:
+            limit: Maximum number of results (default: 50)
+            campaign_status: Filter by campaign status (optional, e.g., "ACTIVE")
+
+        Returns:
+            List of campaign records with customer information
+        """
+        status_filter = ""
+        params = {"campaigner_id": self.campaigner_id, "limit": limit}
+
+        if campaign_status:
+            status_filter = "AND kg.campaign_status = :campaign_status"
+            params["campaign_status"] = campaign_status
+
+        query = f"""
+        SELECT DISTINCT ON (kg.campaign_id, c.id)
+            kg.campaign_id, kg.campaign_name, kg.campaign_status,
+            kg.advertising_channel, kg.campaign_objective, kg.daily_budget,
+            kg.target_audience, kg.created_at, kg.updated_at,
+            c.id as customer_id, c.full_name as customer_name
+        FROM kpi_goals kg
+        JOIN customers c ON c.id = kg.customer_id
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE camp.id = :campaigner_id
+          AND c.is_active = true
+          {status_filter}
+        ORDER BY kg.campaign_id, c.id, kg.updated_at DESC
+        LIMIT :limit
+        """
+
+        logger.info(
+            f"📋 [DatabaseTool] Getting all campaigns for campaigner: {self.campaigner_id}, "
+            f"status: {campaign_status or 'all'}"
+        )
+        return self._execute_query(query, params)
+
+    def get_campaigns_summary_all(self) -> Dict[str, Any]:
+        """
+        Get summary statistics of all campaigns for the campaigner's agency.
+
+        Returns:
+            Dictionary with campaign statistics across all customers
+        """
+        query = """
+        SELECT
+            COUNT(DISTINCT kg.campaign_id) as total_campaigns,
+            COUNT(DISTINCT CASE WHEN kg.campaign_status = 'ACTIVE' THEN kg.campaign_id END) as active_campaigns,
+            COUNT(DISTINCT CASE WHEN kg.campaign_status = 'PAUSED' THEN kg.campaign_id END) as paused_campaigns,
+            COUNT(DISTINCT c.id) as total_customers,
+            COUNT(DISTINCT kg.ad_group_id) as total_ad_groups,
+            COUNT(DISTINCT kg.ad_id) as total_ads,
+            AVG(kg.daily_budget) as avg_daily_budget,
+            SUM(kg.daily_budget) as total_daily_budget
+        FROM kpi_goals kg
+        JOIN customers c ON c.id = kg.customer_id
+        JOIN campaigners camp ON camp.agency_id = c.agency_id
+        WHERE camp.id = :campaigner_id
+          AND c.is_active = true
+        """
+
+        logger.info(f"📊 [DatabaseTool] Getting overall campaign summary for campaigner: {self.campaigner_id}")
+        results = self._execute_query(query, {"campaigner_id": self.campaigner_id})
+
+        return results[0] if results else {}
+
+
+# Convenience functions for backward compatibility
+def get_agency_info(campaigner_id: int) -> Optional[Dict[str, Any]]:
+    """Get agency info for a campaigner."""
+    tool = DatabaseTool(campaigner_id)
+    return tool.get_agency_info()
+
+
+def get_campaigner_info(campaigner_id: int) -> Optional[Dict[str, Any]]:
+    """Get campaigner info."""
+    tool = DatabaseTool(campaigner_id)
+    return tool.get_campaigner_info()
+
+
+def get_customer_info(campaigner_id: int, customer_id: int) -> Optional[Dict[str, Any]]:
+    """Get customer info."""
+    tool = DatabaseTool(campaigner_id)
+    return tool.get_customer_info(customer_id)
+
+
+def get_kpi_goals(
+    campaigner_id: int, customer_id: int, limit: int = 50, campaign_status: str = "ACTIVE"
+) -> List[Dict[str, Any]]:
+    """Get KPI goals for a customer."""
+    tool = DatabaseTool(campaigner_id)
+    return tool.get_kpi_goals(customer_id, limit, campaign_status)

--- a/app/core/agents/graph/__init__.py
+++ b/app/core/agents/graph/__init__.py
@@ -1,0 +1,25 @@
+"""Chatbot routing workflow for campaign management.
+
+This module implements a conversational interface where a chatbot interacts with users
+to understand their intent and routes tasks to specialized agents.
+"""
+
+from .workflow import ConversationWorkflow, build_graph, get_graph
+from .state import GraphState
+from .nodes import ChatbotNode, AgentExecutorNode, ErrorHandlerNode
+from .agents import AnalyticsCrewPlaceholder, CampaignPlanningCrewPlaceholder, get_agent
+from .sql_agent import SQLBasicInfoAgent
+
+__all__ = [
+    "ChatbotWorkflow",
+    "build_graph",
+    "get_graph",
+    "GraphState",
+    "ConversationWorkflow",
+    "AgentExecutorNode",
+    "ErrorHandlerNode",
+    "SQLBasicInfoAgent",
+    "AnalyticsCrewPlaceholder",
+    "CampaignPlanningCrewPlaceholder",
+    "get_agent"
+]

--- a/app/core/agents/graph/agents.py
+++ b/app/core/agents/graph/agents.py
@@ -1,0 +1,125 @@
+"""Specialized agents for handling specific tasks."""
+
+from typing import Dict, Any
+import logging
+from langchain_openai import ChatOpenAI
+from ..crew.crew import AnalyticsCrew
+from .sql_agent import SQLBasicInfoAgent
+
+logger = logging.getLogger(__name__)
+
+class AnalyticsCrewPlaceholder:
+    """Wrapper for the Analytics Crew.
+
+    This crew gathers information from all campaigns across multiple platforms
+    (Facebook Ads, Google Marketing, etc.) and generate insights.
+    """
+
+    def __init__(self, llm: ChatOpenAI):
+        self.llm = llm
+        self.analytics_crew = AnalyticsCrew()
+
+    def execute(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute an analytics task using the AnalyticsCrew.
+
+        Args:
+            task: Dictionary containing the analytics request with keys:
+                - query: The analytics question/request
+                - context: Additional context (optional)
+                - platforms: List of platforms to analyze (e.g., ["facebook", "google"])
+                - metrics: List of metrics to analyze (optional)
+                - date_range: Dict with 'start' and 'end' dates (optional)
+
+        Returns:
+            Dictionary containing the analytics results
+        """
+        # Extract task details
+        query = task.get("query", "")
+
+        # Build task details for AnalyticsCrew
+        task_details = {
+            "query": query,
+            "platforms": task.get("platforms", ["facebook", "google"]),
+            "metrics": task.get("metrics", ["impressions", "clicks", "conversions", "spend"]),
+            "date_range": task.get("date_range", {"start": "last_30_days", "end": "today"}),
+            "specific_campaigns": task.get("specific_campaigns", None)
+        }
+
+        # Execute the analytics crew
+        crew_result = self.analytics_crew.execute(task_details)
+
+        # Format the response
+        if crew_result.get("success"):
+            return {
+                "status": "completed",
+                "result": crew_result.get("result"),
+                "agent": "analytics_crew",
+                "platforms": crew_result.get("platforms"),
+                "task_details": task_details
+            }
+        else:
+            return {
+                "status": "error",
+                "message": f"Analytics crew execution failed: {crew_result.get('error')}",
+                "agent": "analytics_crew",
+                "task_received": task
+            }
+
+
+class CampaignPlanningCrewPlaceholder:
+    """Placeholder for the Campaign Planning Crew.
+
+    This crew will plan new campaigns, create digital assets,
+    and distribute them to advertising platforms.
+    """
+
+    def __init__(self, llm: ChatOpenAI):
+        self.llm = llm
+
+    def execute(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a campaign planning task.
+
+        Args:
+            task: Dictionary containing the campaign planning request
+
+        Returns:
+            Dictionary containing the campaign plan
+        """
+        # TODO: Implement CrewAI crew for campaign planning
+        # This crew should:
+        # 1. Plan new marketing campaigns based on goals
+        # 2. Create digital assets (copy, images, etc.)
+        # 3. Format and send campaigns to advertising platforms
+
+        return {
+            "status": "placeholder",
+            "message": "Campaign planning crew not yet implemented",
+            "agent": "campaign_planning_crew",
+            "task_received": task
+        }
+
+
+def get_agent(agent_name: str, llm: ChatOpenAI):
+    """Get an agent instance by name.
+
+    Args:
+        agent_name: Name of the agent to retrieve
+        llm: Language model instance
+
+    Returns:
+        Agent instance
+
+    Raises:
+        ValueError: If agent_name is not recognized
+    """
+    agents = {
+        "basic_info_agent": SQLBasicInfoAgent,  # Using SQL-based agent
+        # "basic_info_agent_legacy": BasicInfoAgent,  # Legacy version kept for reference
+        "analytics_crew": AnalyticsCrewPlaceholder,
+        "campaign_planning_crew": CampaignPlanningCrewPlaceholder
+    }
+
+    if agent_name not in agents:
+        raise ValueError(f"Unknown agent: {agent_name}")
+
+    return agents[agent_name](llm)

--- a/app/core/agents/graph/nodes.py
+++ b/app/core/agents/graph/nodes.py
@@ -1,0 +1,248 @@
+"""Node implementations for the chatbot routing workflow."""
+
+from typing import Dict, Any
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage, AIMessage
+import json
+import logging
+
+from .state import GraphState
+from .agents import get_agent
+from ..database.tools import DatabaseTool
+
+logger = logging.getLogger(__name__)
+
+
+class ChatbotNode:
+    """Chatbot node that interacts with users and routes tasks to specialized agents."""
+
+    def __init__(self, llm: ChatOpenAI):
+        self.llm = llm
+        self.system_prompt = """You are a helpful marketing campaign assistant chatbot.
+
+Your role is to:
+1. Have natural conversations with users (campaigners) to understand their intent
+2. Ask clarifying follow-up questions when needed
+3. Route tasks to the appropriate specialized agent when you have enough information
+
+IMPORTANT: The user is already authenticated and their campaigner_id is automatically provided to all agents.
+You do NOT need to ask users for their ID - it's already available in the system.
+
+Available agents you can route to:
+- basic_info_agent: Answers questions about agency info, user info, campaigns, and KPIs using database access
+- analytics_crew: Gathers and analyzes data from all advertising platforms (Facebook Ads, Google Marketing, etc.)
+- campaign_planning_crew: Plans new campaigns, creates digital assets, and deploys them to platforms
+
+When you understand what the user needs, respond with a JSON object specifying which agent to use:
+{
+    "agent": "basic_info_agent" | "analytics_crew" | "campaign_planning_crew",
+    "task": {
+        "query": "the specific task description",
+        "context": {}
+    },
+    "ready": true
+}
+
+If you need more information, respond naturally asking for clarification:
+{
+    "message": "your clarifying question or response",
+    "ready": false
+}
+
+Be conversational, helpful, and ask follow-up questions naturally to understand user intent.
+Remember: You have access to the user's identity through the system - never ask them for their campaigner ID.
+"""
+
+    def process(self, state: GraphState) -> Dict[str, Any]:
+        """Process the conversation and determine next steps.
+
+        Args:
+            state: Current graph state
+
+        Returns:
+            Updated state fields
+        """
+        logger.info("🤖 [ChatbotNode] Processing conversation")
+
+        # Get campaigner_id from state
+        campaigner_id = state.get("campaigner_id", 1)
+        logger.debug(f"👤 [ChatbotNode] Processing for campaigner: {campaigner_id}")
+
+        messages = [
+            SystemMessage(content=self.system_prompt),
+            *state["messages"]
+        ]
+        logger.debug(f"📤 [ChatbotNode] Sending {len(messages)} messages to LLM")
+        response = self.llm.invoke(messages)
+        logger.debug(f"📥 [ChatbotNode] Received response: {response.content[:100]}...")
+
+        try:
+            # Try to parse JSON response
+            content = response.content
+            if "```json" in content:
+                content = content.split("```json")[1].split("```")[0].strip()
+            elif "```" in content:
+                content = content.split("```")[1].split("```")[0].strip()
+
+            parsed = json.loads(content)
+            logger.debug(f"✅ [ChatbotNode] Parsed JSON response: ready={parsed.get('ready')}")
+
+            if parsed.get("ready"):
+                # User intent is clear, route to agent
+                agent_name = parsed.get("agent")
+                task = parsed.get("task", {})
+
+                # Add campaigner_id and context for authorization and personalization
+                campaigner_id = state.get("campaigner_id")
+                if campaigner_id:
+                    task["campaigner_id"] = campaigner_id
+                    logger.debug(f"🔐 [ChatbotNode] Added campaigner_id to task: {campaigner_id}")
+
+                    # Gather agency and campaigner context for agents
+                    try:
+                        db_tool = DatabaseTool(campaigner_id)
+                        agency_info = db_tool.get_agency_info()
+                        campaigner_info = db_tool.get_campaigner_info()
+
+                        task["context"] = {
+                            "agency": agency_info,
+                            "campaigner": campaigner_info
+                        }
+                        logger.debug(f"📊 [ChatbotNode] Added context to task: agency={agency_info.get('name') if agency_info else None}")
+                    except Exception as e:
+                        logger.warning(f"⚠️  [ChatbotNode] Failed to gather context: {str(e)}")
+                        task["context"] = {}
+
+                logger.info(f"✅ [ChatbotNode] Intent ready! Routing to agent: {agent_name}")
+                logger.debug(f"📋 [ChatbotNode] Task: {task}")
+
+                return {
+                    "next_agent": agent_name,
+                    "agent_task": task,
+                    "needs_clarification": False,
+                    "conversation_complete": False
+                }
+            else:
+                # Need more clarification
+                clarification_msg = parsed.get("message", response.content)
+                logger.info(f"❓ [ChatbotNode] Need clarification: '{clarification_msg[:100]}...'")
+                return {
+                    "messages": state["messages"] + [AIMessage(content=clarification_msg)],
+                    "needs_clarification": True,
+                    "conversation_complete": False,
+                    "next_agent": None
+                }
+
+        except (json.JSONDecodeError, KeyError) as e:
+            # If not JSON, treat as clarification message
+            logger.warning(f"⚠️  [ChatbotNode] Failed to parse JSON, treating as clarification: {str(e)}")
+            return {
+                "messages": state["messages"] + [AIMessage(content=response.content)],
+                "needs_clarification": True,
+                "conversation_complete": False,
+                "next_agent": None
+            }
+
+
+class AgentExecutorNode:
+    """Node that executes the appropriate specialized agent."""
+
+    def __init__(self, llm: ChatOpenAI):
+        self.llm = llm
+
+    def execute(self, state: GraphState) -> Dict[str, Any]:
+        """Execute the selected agent with the given task.
+
+        Args:
+            state: Current graph state
+
+        Returns:
+            Updated state fields with agent results
+        """
+        agent_name = state.get("next_agent")
+        task = state.get("agent_task", {})
+
+        logger.info(f"⚙️  [AgentExecutor] Executing agent: {agent_name}")
+
+        if not agent_name:
+            logger.error("❌ [AgentExecutor] No agent specified")
+            return {
+                "error": "No agent specified for execution",
+                "conversation_complete": True
+            }
+
+        try:
+            # Get and execute the agent
+            logger.debug(f"🔍 [AgentExecutor] Getting agent instance: {agent_name}")
+            agent = get_agent(agent_name, self.llm)
+
+            logger.info(f"🚀 [AgentExecutor] Executing {agent_name} with task...")
+            logger.debug(f"📋 [AgentExecutor] Task details: {task}")
+            result = agent.execute(task)
+            logger.info(f"✅ [AgentExecutor] Agent {agent_name} completed. Status: {result.get('status')}")
+
+            # Format response message
+            response_message = self._format_agent_response(result)
+            logger.debug(f"💬 [AgentExecutor] Response: '{response_message[:100]}...'")
+
+            return {
+                "agent_result": result,
+                "messages": state["messages"] + [AIMessage(content=response_message)],
+                "conversation_complete": True,
+                "error": None
+            }
+
+        except Exception as e:
+            logger.error(f"❌ [AgentExecutor] Agent execution failed: {str(e)}", exc_info=True)
+
+            # Create user-friendly error message
+            error_message = f"I encountered an error while processing your request: {str(e)}"
+
+            return {
+                "error": str(e),
+                "messages": state["messages"] + [AIMessage(content=error_message)],
+                "conversation_complete": True
+            }
+
+    def _format_agent_response(self, result: Dict[str, Any]) -> str:
+        """Format the agent result as a user-friendly message.
+
+        Args:
+            result: Agent execution result
+
+        Returns:
+            Formatted message string
+        """
+        status = result.get("status")
+        agent = result.get("agent", "Unknown agent")
+
+        if status == "completed":
+            return result.get("result", "Task completed successfully.")
+        elif status == "placeholder":
+            message = result.get("message", "")
+            return f"{message}\n\nThis feature is coming soon!"
+        else:
+            return f"Task processed by {agent}."
+
+
+class ErrorHandlerNode:
+    """Node for handling errors in the workflow."""
+
+    def handle(self, state: GraphState) -> Dict[str, Any]:
+        """Handle errors and provide user feedback.
+
+        Args:
+            state: Current graph state
+
+        Returns:
+            Updated state fields
+        """
+        error_msg = state.get("error", "An unknown error occurred")
+
+        return {
+            "messages": state["messages"] + [
+                AIMessage(content=f"I encountered an issue: {error_msg}. Please try again.")
+            ],
+            "error": None,
+            "conversation_complete": True
+        }

--- a/app/core/agents/graph/sql_agent.py
+++ b/app/core/agents/graph/sql_agent.py
@@ -1,0 +1,215 @@
+"""SQL-based BasicInfoAgent using LangChain tools."""
+
+import logging
+import json
+from typing import Dict, Any
+from langchain_openai import ChatOpenAI
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+
+from ..tools.postgres_tool import PostgresTool
+
+logger = logging.getLogger(__name__)
+
+
+class SQLBasicInfoAgent:
+    """SQL Expert Agent that generates and executes database queries.
+
+    This agent:
+    1. Analyzes the user's question
+    2. Generates appropriate SQL SELECT queries
+    3. The SQL is validated by another LLM
+    4. Executes validated queries via PostgresTool
+    5. Interprets results and answers in the user's language
+    """
+
+    def __init__(self, llm: ChatOpenAI):
+        self.llm = llm
+        self.validator_llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)  # Dedicated validator
+
+    def execute(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a database query task.
+
+        Args:
+            task: Dictionary containing:
+                - query: The user's question
+                - campaigner_id: ID of the authenticated user (REQUIRED)
+                - context: Optional additional context
+
+        Returns:
+            Dictionary containing the result
+        """
+        query = task.get("query", "")
+        campaigner_id = task.get("campaigner_id")
+        context = task.get("context", {})
+
+        logger.info(f"🤖 [SQLBasicInfoAgent] Processing query for campaigner: {campaigner_id}")
+        logger.debug(f"📝 [SQLBasicInfoAgent] Query: '{query[:100]}...'")
+
+        # Validate campaigner_id
+        if not campaigner_id:
+            logger.error("❌ [SQLBasicInfoAgent] No campaigner_id provided")
+            return {
+                "status": "error",
+                "result": "Authentication required. No campaigner ID provided.",
+                "agent": "basic_info_agent",
+            }
+
+        try:
+            # Create PostgresTool instance
+            postgres_tool = PostgresTool(campaigner_id=campaigner_id)
+
+            # Get schema information
+            schema_info = postgres_tool.get_schema_info()
+
+            # Create the agent with tools
+            agent = self._create_agent(postgres_tool, schema_info, context)
+
+            # Execute the agent
+            logger.info(f"🚀 [SQLBasicInfoAgent] Executing agent")
+            result = agent.invoke({
+                "input": query,
+                "chat_history": []
+            })
+
+            logger.info(f"✅ [SQLBasicInfoAgent] Agent completed")
+            logger.debug(f"💬 [SQLBasicInfoAgent] Output: {result['output'][:200]}...")
+
+            return {
+                "status": "completed",
+                "result": result["output"],
+                "agent": "basic_info_agent",
+            }
+
+        except Exception as e:
+            logger.error(f"❌ [SQLBasicInfoAgent] Error: {str(e)}", exc_info=True)
+            return {
+                "status": "error",
+                "result": f"An error occurred while processing your request: {str(e)}",
+                "agent": "basic_info_agent",
+            }
+
+    def _create_agent(
+        self,
+        postgres_tool: PostgresTool,
+        schema_info: Dict[str, Any],
+        context: Dict[str, Any]
+    ) -> AgentExecutor:
+        """Create a LangChain agent with PostgresTool.
+
+        Args:
+            postgres_tool: PostgreSQL query tool
+            schema_info: Database schema information
+            context: Additional context (agency info, etc.)
+
+        Returns:
+            Configured AgentExecutor
+        """
+        # Format schema for prompt - escape curly braces for LangChain template
+        schema_str = json.dumps(schema_info, indent=2).replace("{", "{{").replace("}", "}}")
+
+        # Format context from ChatbotNode
+        context_parts = []
+        if context.get("agency"):
+            agency = context["agency"]
+            context_parts.append(f"Agency: {agency.get('name')} (ID: {agency.get('id')}), Status: {agency.get('status')}")
+        if context.get("campaigner"):
+            camp = context["campaigner"]
+            context_parts.append(f"User: {camp.get('full_name')} ({camp.get('email')}), Role: {camp.get('role')}")
+
+        context_str = "\n".join(context_parts) if context_parts else ""
+
+        # Build the system message with proper escaping
+        system_message = """You are an expert SQL database assistant with READ-ONLY access to a PostgreSQL database.
+
+Your role is to:
+1. Understand the user's question
+2. Write efficient SELECT queries to retrieve the needed data
+3. Execute queries using the postgres_query tool
+4. Interpret results and provide clear answers
+5. **ALWAYS respond in the same language as the user's query** (Hebrew/English/etc.)
+
+Database Schema:
+```json
+""" + schema_str + """
+```
+
+""" + context_str + """
+
+
+
+IMPORTANT SQL WRITING RULES:
+1. ALL queries MUST include security filtering with proper JOINs:
+
+   **For kpi_goals or kpi_values tables:**
+   - These tables do NOT have agency_id directly
+   - MUST join through customers table:
+   ```sql
+   FROM kpi_goals kg
+   JOIN customers c ON c.id = kg.customer_id
+   JOIN campaigners camp ON camp.agency_id = c.agency_id
+   WHERE camp.id = :campaigner_id
+   ```
+
+   **For customers table:**
+   - Join directly with campaigners:
+   ```sql
+   FROM customers c
+   JOIN campaigners camp ON camp.agency_id = c.agency_id
+   WHERE camp.id = :campaigner_id
+   ```
+
+   **For agencies or campaigners table:**
+   - Filter by campaigner_id directly
+
+2. Example secure query for campaigns:
+```sql
+SELECT DISTINCT kg.campaign_id, kg.campaign_name, kg.campaign_status,
+       c.full_name as customer_name
+FROM kpi_goals kg
+JOIN customers c ON c.id = kg.customer_id
+JOIN campaigners camp ON camp.agency_id = c.agency_id
+WHERE camp.id = :campaigner_id
+  AND kg.campaign_status = 'ACTIVE'
+LIMIT 20
+```
+
+3. Only use SELECT queries - no INSERT, UPDATE, DELETE, DROP or DDL
+4. Use proper JOINs to ensure security filtering
+5. Include LIMIT clauses to prevent large result sets (max 100 rows)
+6. Use meaningful column aliases for clarity
+
+When answering:
+- Be specific and reference actual data from query results
+- Format lists and tables clearly
+- Include relevant IDs
+- If no data found, explain what was searched
+- Respond in the user's language
+"""
+
+        # Create prompt template
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", system_message),
+            MessagesPlaceholder(variable_name="chat_history"),
+            ("human", "{input}"),
+            MessagesPlaceholder(variable_name="agent_scratchpad"),
+        ])
+
+        # Create tool-calling agent
+        agent = create_tool_calling_agent(
+            llm=self.llm,
+            tools=[postgres_tool],
+            prompt=prompt
+        )
+
+        # Create agent executor
+        agent_executor = AgentExecutor(
+            agent=agent,
+            tools=[postgres_tool],
+            verbose=True,
+            max_iterations=5,
+            handle_parsing_errors=True,
+            return_intermediate_steps=False
+        )
+
+        return agent_executor

--- a/app/core/agents/graph/state.py
+++ b/app/core/agents/graph/state.py
@@ -1,0 +1,27 @@
+"""State management for the chatbot routing workflow."""
+
+from typing import TypedDict, List, Dict, Any, Optional, Literal
+from langgraph.graph import MessagesState
+
+
+class GraphState(MessagesState):
+    """State for the chatbot routing graph.
+
+    This state manages the conversation flow where a chatbot interacts with users
+    and routes tasks to specialized agents based on intent.
+    """
+
+    # Routing information
+    next_agent: Optional[Literal["basic_info_agent", "analytics_crew", "campaign_planning_crew"]]
+    agent_task: Optional[Dict[str, Any]]
+    agent_result: Optional[Dict[str, Any]]
+
+    # Conversation control
+    needs_clarification: bool
+    conversation_complete: bool
+
+    # Error handling
+    error: Optional[str]
+
+    # User context (for authorization and data filtering)
+    campaigner_id: Optional[int] # ID of the authenticated campaigner

--- a/app/core/agents/graph/workflow.py
+++ b/app/core/agents/graph/workflow.py
@@ -1,0 +1,245 @@
+"""Main LangGraph workflow for chatbot routing."""
+
+from typing import Literal
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+import os
+import logging
+
+from .state import GraphState
+from .nodes import ChatbotNode, AgentExecutorNode, ErrorHandlerNode
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationWorkflow:
+    """LangGraph workflow for chatbot-based agent routing.
+
+    This workflow implements a conversational interface where a chatbot:
+    1. Interacts with users to understand their intent
+    2. Asks follow-up questions when needed
+    3. Routes tasks to specialized agents when ready
+    """
+
+    def __init__(self, campaigner_id: int = 1):
+        logger.info("🏗️  [Workflow] Initializing ConversationWorkflow")
+
+        # Store campaigner_id for this workflow
+        self.campaigner_id = campaigner_id
+        logger.debug(f"👤 [Workflow] Campaigner ID: {campaigner_id}")
+
+        # Initialize conversation state (persistent across messages)
+        self.conversation_state = {
+            "messages": [],
+            "next_agent": None,
+            "agent_task": None,
+            "agent_result": None,
+            "needs_clarification": False,
+            "conversation_complete": False,
+            "error": None,
+            "campaigner_id": campaigner_id
+        }
+
+        # Initialize LLM
+        self.llm = ChatOpenAI(
+            model="gpt-4o-mini",
+            temperature=0.7,
+            api_key=os.getenv("OPENAI_API_KEY")
+        )
+        logger.debug(f"🤖 [Workflow] LLM initialized: gpt-4o-mini")
+
+        # Initialize nodes
+        self.chatbot_node = ChatbotNode(self.llm)
+        self.agent_executor_node = AgentExecutorNode(self.llm)
+        self.error_handler_node = ErrorHandlerNode()
+        logger.debug("📦 [Workflow] Nodes initialized")
+
+        # Build and compile graph
+        self.graph = self._build_graph()
+        self.app = self.graph.compile()
+        logger.debug("✅ [Workflow] Graph compiled and ready")
+
+    def _build_graph(self) -> StateGraph:
+        """Build the chatbot routing graph."""
+
+        workflow = StateGraph(GraphState)
+
+        # Add nodes
+        workflow.add_node("chatbot", self.chatbot_node.process)
+        workflow.add_node("execute_agent", self.agent_executor_node.execute)
+        workflow.add_node("handle_error", self.error_handler_node.handle)
+
+        # Set entry point
+        workflow.set_entry_point("chatbot")
+
+        # Add conditional edges
+        workflow.add_conditional_edges(
+            "chatbot",
+            self._route_from_chatbot,
+            {
+                "execute_agent": "execute_agent",
+                "clarify": END,
+                "error": "handle_error"
+            }
+        )
+
+        workflow.add_edge("execute_agent", END)
+        workflow.add_edge("handle_error", END)
+
+        return workflow
+
+    def _route_from_chatbot(
+        self, state: GraphState
+    ) -> Literal["execute_agent", "clarify", "error"]:
+        """Route from chatbot node based on state.
+
+        Args:
+            state: Current graph state
+
+        Returns:
+            Next node to execute
+        """
+        if state.get("error"):
+            logger.error("🔀 [Workflow] Routing to: error handler")
+            return "error"
+
+        if state.get("needs_clarification"):
+            logger.info("🔀 [Workflow] Routing to: clarify (END)")
+            return "clarify"
+
+        if state.get("next_agent"):
+            agent_name = state.get("next_agent")
+            logger.info(f"🔀 [Workflow] Routing to: execute_agent ({agent_name})")
+            return "execute_agent"
+
+        logger.info("🔀 [Workflow] Routing to: clarify (default)")
+        return "clarify"
+
+    def process_message(self, message: str) -> dict:
+        """Process a user message and return the updated state.
+
+        Args:
+            message: User's message
+
+        Returns:
+            Updated state after processing
+        """
+        logger.info(f"🔄 [Workflow] Processing message: '{message[:50]}...'")
+        logger.debug(f"♻️  [Workflow] Continuing with {len(self.conversation_state.get('messages', []))} existing messages")
+
+        # Add user message to persistent state
+        self.conversation_state["messages"].append(HumanMessage(content=message))
+
+        # Reset flags for this turn
+        self.conversation_state["next_agent"] = None
+        self.conversation_state["agent_task"] = None
+        self.conversation_state["agent_result"] = None
+        self.conversation_state["needs_clarification"] = False
+        self.conversation_state["error"] = None
+
+        # Run the graph with persistent state
+        logger.debug("⚙️  [Workflow] Invoking graph...")
+        result = self.app.invoke(self.conversation_state)
+
+        # Update persistent state with result
+        self.conversation_state.update(result)
+
+        logger.info(
+            f"✅ [Workflow] Graph completed | "
+            f"Agent: {result.get('next_agent', 'None')} | "
+            f"Complete: {result.get('conversation_complete', False)} | "
+            f"Total messages: {len(self.conversation_state['messages'])}"
+        )
+
+        return self.conversation_state
+
+
+# Module-level function to build and return the compiled graph
+def build_graph():
+    """Build and return the compiled chatbot routing graph.
+
+    This function is used by LangGraph CLI and for module-level exports.
+
+    Returns:
+        Compiled graph application
+    """
+    # Initialize LLM
+    llm = ChatOpenAI(
+        model="gpt-4o-mini",
+        temperature=0.7,
+        api_key=os.getenv("OPENAI_API_KEY")
+    )
+
+    # Initialize nodes
+    chatbot_node = ChatbotNode(llm)
+    agent_executor_node = AgentExecutorNode(llm)
+    error_handler_node = ErrorHandlerNode()
+
+    # Create graph
+    workflow = StateGraph(GraphState)
+
+    # Add nodes
+    workflow.add_node("chatbot", chatbot_node.process)
+    workflow.add_node("execute_agent", agent_executor_node.execute)
+    workflow.add_node("handle_error", error_handler_node.handle)
+
+    # Set entry point
+    workflow.set_entry_point("chatbot")
+
+    # Routing function
+    def route_from_chatbot(
+        state: GraphState
+    ) -> Literal["execute_agent", "clarify", "error"]:
+        """Route from chatbot node based on state."""
+        if state.get("error"):
+            return "error"
+        if state.get("needs_clarification"):
+            return "clarify"
+        if state.get("next_agent"):
+            return "execute_agent"
+        return "clarify"
+
+    # Add edges
+    workflow.add_conditional_edges(
+        "chatbot",
+        route_from_chatbot,
+        {
+            "execute_agent": "execute_agent",
+            "clarify": END,
+            "error": "handle_error"
+        }
+    )
+
+    workflow.add_edge("execute_agent", END)
+    workflow.add_edge("handle_error", END)
+
+    # Compile and return
+    return workflow.compile()
+
+
+# Lazy graph initialization
+_graph = None
+
+
+def get_graph():
+    """Get or create the graph instance.
+
+    Returns:
+        Compiled graph application
+    """
+    global _graph
+    if _graph is None:
+        _graph = build_graph()
+    return _graph
+
+
+# Export the graph for LangGraph CLI
+try:
+    graph = build_graph()
+except Exception as e:
+    # During testing, graph will be built lazily
+    if not os.getenv("OPENAI_API_KEY"):
+        graph = None
+    else:
+        raise

--- a/app/core/agents/mcp_clients/__init__.py
+++ b/app/core/agents/mcp_clients/__init__.py
@@ -1,0 +1,15 @@
+"""MCP (Model Context Protocol) client integrations."""
+
+# Avoid circular imports by using lazy imports
+__all__ = ["FacebookMCPClient", "GoogleMCPClient"]
+
+
+def __getattr__(name):
+    """Lazy import to avoid circular dependency issues."""
+    if name == "FacebookMCPClient":
+        from .facebook_client import FacebookMCPClient
+        return FacebookMCPClient
+    elif name == "GoogleMCPClient":
+        from .google_client import GoogleMCPClient
+        return GoogleMCPClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/core/agents/mcp_clients/base.py
+++ b/app/core/agents/mcp_clients/base.py
@@ -1,0 +1,129 @@
+"""Base MCP client implementation."""
+
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from contextlib import asynccontextmanager
+import asyncio
+import os
+
+
+class BaseMCPClient(ABC):
+    """Base class for MCP client implementations."""
+
+    def __init__(self, server_path: str, server_args: Optional[List[str]] = None):
+        """
+        Initialize MCP client.
+
+        Args:
+            server_path: Path to the MCP server executable
+            server_args: Additional arguments for the server
+        """
+        self.server_path = server_path
+        self.server_args = server_args or []
+        self.session: Optional[ClientSession] = None
+        self._client_context = None
+        self._read_stream = None
+        self._write_stream = None
+
+    @abstractmethod
+    def get_server_command(self) -> List[str]:
+        """Get the command to start the MCP server."""
+        pass
+
+    @abstractmethod
+    def get_tools(self) -> List[Any]:
+        """Get the tools provided by this MCP server."""
+        pass
+
+    async def connect(self):
+        """Connect to the MCP server."""
+        server_params = StdioServerParameters(
+            command=self.get_server_command()[0],
+            args=self.get_server_command()[1:],
+            env=os.environ.copy()
+        )
+
+        # Create stdio client context
+        self._client_context = stdio_client(server_params)
+        self._read_stream, self._write_stream = await self._client_context.__aenter__()
+
+        # Create session
+        self.session = ClientSession(self._read_stream, self._write_stream)
+        await self.session.__aenter__()
+
+        # Initialize the session
+        await self.session.initialize()
+
+    async def disconnect(self):
+        """Disconnect from the MCP server."""
+        if self.session:
+            await self.session.__aexit__(None, None, None)
+
+        if self._client_context:
+            await self._client_context.__aexit__(None, None, None)
+
+    async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        """
+        Call a tool on the MCP server.
+
+        Args:
+            tool_name: Name of the tool to call
+            arguments: Arguments to pass to the tool
+
+        Returns:
+            Tool execution result
+        """
+        if not self.session:
+            raise RuntimeError("Not connected to MCP server. Call connect() first.")
+
+        result = await self.session.call_tool(tool_name, arguments)
+        return result
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        """List available tools from the MCP server."""
+        if not self.session:
+            raise RuntimeError("Not connected to MCP server. Call connect() first.")
+
+        result = await self.session.list_tools()
+        return result.tools
+
+    def close(self):
+        """Synchronously close the connection."""
+        if self.session or self._client_context:
+            try:
+                asyncio.run(self.disconnect())
+            except Exception as e:
+                print(f"Error closing MCP client: {e}")
+
+
+class MCPTool:
+    """Wrapper for MCP tools to make them compatible with CrewAI/LangChain."""
+
+    def __init__(self, client: BaseMCPClient, tool_name: str, tool_description: str):
+        """
+        Initialize MCP tool wrapper.
+
+        Args:
+            client: The MCP client instance
+            tool_name: Name of the tool
+            tool_description: Description of what the tool does
+        """
+        self.client = client
+        self.tool_name = tool_name
+        self.tool_description = tool_description
+        self.name = tool_name
+        self.description = tool_description
+
+    async def _arun(self, **kwargs) -> Any:
+        """Async execution of the tool."""
+        return await self.client.call_tool(self.tool_name, kwargs)
+
+    def _run(self, **kwargs) -> Any:
+        """Sync execution of the tool."""
+        return asyncio.run(self._arun(**kwargs))
+
+    def __call__(self, **kwargs) -> Any:
+        """Make the tool callable."""
+        return self._run(**kwargs)

--- a/app/core/agents/mcp_clients/facebook_client.py
+++ b/app/core/agents/mcp_clients/facebook_client.py
@@ -1,0 +1,135 @@
+"""Facebook Ads MCP client."""
+
+from typing import List, Any
+import os
+from .base import BaseMCPClient, MCPTool
+
+
+class FacebookMCPClient(BaseMCPClient):
+    """MCP client for Facebook Ads data."""
+
+    def __init__(self):
+        """Initialize Facebook Ads MCP client."""
+        server_path = os.getenv(
+            "FACEBOOK_MCP_SERVER_PATH",
+            "npx"  # Default to npx if server path not specified
+        )
+        super().__init__(server_path)
+
+    def get_server_command(self) -> List[str]:
+        """Get the command to start the Facebook Ads MCP server."""
+        # This is a placeholder - actual command depends on the MCP server implementation
+        # Example: ["node", "/path/to/facebook-ads-mcp-server/index.js"]
+        # or: ["npx", "@modelcontextprotocol/server-facebook-ads"]
+
+        if self.server_path == "npx":
+            return ["npx", "-y", "@modelcontextprotocol/server-facebook-ads"]
+        else:
+            return ["node", self.server_path]
+
+    def get_tools(self) -> List[Any]:
+        """Get CrewAI-compatible tools for Facebook Ads."""
+
+        # Define Facebook Ads tools
+        tools = [
+            MCPTool(
+                client=self,
+                tool_name="get_campaigns",
+                tool_description="""Get Facebook Ads campaigns data.
+                Arguments:
+                - account_id: Facebook Ads account ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                - fields: List of fields to retrieve (e.g., ['name', 'impressions', 'clicks'])
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_campaign_insights",
+                tool_description="""Get detailed insights for specific campaigns.
+                Arguments:
+                - campaign_ids: List of campaign IDs
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                - metrics: List of metrics (e.g., ['impressions', 'clicks', 'spend', 'conversions'])
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_ad_sets",
+                tool_description="""Get Facebook Ads ad sets data.
+                Arguments:
+                - campaign_id: Campaign ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_audience_insights",
+                tool_description="""Get audience demographics and behavior insights.
+                Arguments:
+                - account_id: Facebook Ads account ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                """
+            ),
+        ]
+
+        return tools
+
+
+class MockFacebookMCPClient(BaseMCPClient):
+    """Mock Facebook MCP client for testing without real MCP server."""
+
+    def __init__(self):
+        """Initialize mock client."""
+        # Don't call super().__init__() to avoid requiring server path
+        self.server_path = "mock"
+        self.server_args = []
+        self.session = None
+
+    def get_server_command(self) -> List[str]:
+        """Return mock command."""
+        return ["echo", "mock"]
+
+    async def connect(self):
+        """Mock connect - does nothing."""
+        pass
+
+    async def disconnect(self):
+        """Mock disconnect - does nothing."""
+        pass
+
+    async def call_tool(self, tool_name: str, arguments: dict) -> dict:
+        """Return mock data."""
+        return {
+            "success": True,
+            "data": {
+                "campaigns": [
+                    {
+                        "id": "123456",
+                        "name": "Summer Campaign 2025",
+                        "impressions": 150000,
+                        "clicks": 4500,
+                        "spend": 2500.00,
+                        "conversions": 120
+                    }
+                ]
+            }
+        }
+
+    def get_tools(self) -> List[Any]:
+        """Get mock tools."""
+        return [
+            MCPTool(
+                client=self,
+                tool_name="get_campaigns",
+                tool_description="Get Facebook Ads campaigns data (MOCK)"
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_campaign_insights",
+                tool_description="Get campaign insights (MOCK)"
+            ),
+        ]

--- a/app/core/agents/mcp_clients/google_client.py
+++ b/app/core/agents/mcp_clients/google_client.py
@@ -1,0 +1,147 @@
+"""Google Analytics MCP client."""
+
+from typing import List, Any
+import os
+from .base import BaseMCPClient, MCPTool
+
+
+class GoogleMCPClient(BaseMCPClient):
+    """MCP client for Google Analytics data."""
+
+    def __init__(self):
+        """Initialize Google Analytics MCP client."""
+        server_path = os.getenv(
+            "GOOGLE_MCP_SERVER_PATH",
+            "npx"  # Default to npx if server path not specified
+        )
+        super().__init__(server_path)
+
+    def get_server_command(self) -> List[str]:
+        """Get the command to start the Google Analytics MCP server."""
+        # This is a placeholder - actual command depends on the MCP server implementation
+        # Example: ["node", "/path/to/google-analytics-mcp-server/index.js"]
+        # or: ["npx", "@modelcontextprotocol/server-google-analytics"]
+
+        if self.server_path == "npx":
+            return ["npx", "-y", "@modelcontextprotocol/server-google-analytics"]
+        else:
+            return ["node", self.server_path]
+
+    def get_tools(self) -> List[Any]:
+        """Get CrewAI-compatible tools for Google Analytics."""
+
+        # Define Google Analytics tools
+        tools = [
+            MCPTool(
+                client=self,
+                tool_name="get_analytics_report",
+                tool_description="""Get Google Analytics data report.
+                Arguments:
+                - property_id: GA4 property ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                - metrics: List of metrics (e.g., ['sessions', 'users', 'bounceRate'])
+                - dimensions: List of dimensions (e.g., ['date', 'source', 'medium'])
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_traffic_sources",
+                tool_description="""Get traffic sources breakdown.
+                Arguments:
+                - property_id: GA4 property ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_conversion_funnel",
+                tool_description="""Get conversion funnel data.
+                Arguments:
+                - property_id: GA4 property ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                - funnel_name: Name of the conversion funnel
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_user_demographics",
+                tool_description="""Get user demographics data.
+                Arguments:
+                - property_id: GA4 property ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                """
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_page_performance",
+                tool_description="""Get page-level performance data.
+                Arguments:
+                - property_id: GA4 property ID
+                - date_start: Start date (YYYY-MM-DD)
+                - date_end: End date (YYYY-MM-DD)
+                """
+            ),
+        ]
+
+        return tools
+
+
+class MockGoogleMCPClient(BaseMCPClient):
+    """Mock Google Analytics MCP client for testing without real MCP server."""
+
+    def __init__(self):
+        """Initialize mock client."""
+        # Don't call super().__init__() to avoid requiring server path
+        self.server_path = "mock"
+        self.server_args = []
+        self.session = None
+
+    def get_server_command(self) -> List[str]:
+        """Return mock command."""
+        return ["echo", "mock"]
+
+    async def connect(self):
+        """Mock connect - does nothing."""
+        pass
+
+    async def disconnect(self):
+        """Mock disconnect - does nothing."""
+        pass
+
+    async def call_tool(self, tool_name: str, arguments: dict) -> dict:
+        """Return mock data."""
+        return {
+            "success": True,
+            "data": {
+                "sessions": 45000,
+                "users": 32000,
+                "bounce_rate": 42.5,
+                "conversions": 890,
+                "conversion_rate": 1.98,
+                "traffic_sources": {
+                    "organic": 18000,
+                    "direct": 12000,
+                    "paid": 10000,
+                    "social": 5000
+                }
+            }
+        }
+
+    def get_tools(self) -> List[Any]:
+        """Get mock tools."""
+        return [
+            MCPTool(
+                client=self,
+                tool_name="get_analytics_report",
+                tool_description="Get Google Analytics report (MOCK)"
+            ),
+            MCPTool(
+                client=self,
+                tool_name="get_traffic_sources",
+                tool_description="Get traffic sources (MOCK)"
+            ),
+        ]

--- a/app/core/agents/tools/__init__.py
+++ b/app/core/agents/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Tools for LangChain agents."""
+
+from .postgres_tool import PostgresTool
+from .sql_validator import SQLValidator
+
+__all__ = ["PostgresTool", "SQLValidator"]

--- a/app/core/agents/tools/postgres_tool.py
+++ b/app/core/agents/tools/postgres_tool.py
@@ -1,0 +1,327 @@
+"""PostgreSQL query execution tool for LangChain agents.
+
+This tool provides a secure interface for executing READ-ONLY SQL queries
+against the PostgreSQL database with automatic security filtering.
+"""
+
+import logging
+import re
+from typing import Dict, Any, List, Optional, get_type_hints, get_origin, get_args
+from sqlalchemy import text
+from langchain.tools import BaseTool
+from pydantic import Field as PydanticField
+from sqlmodel import Field as SQLModelField
+
+from app.core.agents.database.connection import get_db_connection
+# from ..database.connection import get_db_connection
+
+from .sql_validator import SQLValidator
+from ....models import (
+    Agency, Campaigner, Customer,
+    KpiGoal, KpiValue, DigitalAsset, Connection,
+    RTMTable, QuestionsTable
+)
+
+logger = logging.getLogger(__name__)
+
+class PostgresTool(BaseTool):
+    """Tool for executing validated SQL queries against PostgreSQL.
+
+    This tool ensures:
+    - Read-only access (SELECT queries only)
+    - Automatic security filtering by campaigner's agency
+    - Query validation and sanitization
+    - Proper error handling and logging
+    """
+
+    name: str = "postgres_query"
+    description: str = """Execute a SELECT SQL query against the PostgreSQL database.
+
+    This tool can query the following tables:
+    - agencies: Agency information
+    - campaigners: Campaigner (user) details
+    - customers: Customer/client information
+    - kpi_goals: Campaign goals and KPI targets
+    - kpi_values: Actual KPI measurements
+    - digital_assets: Digital assets (social media, analytics accounts, etc.)
+    - connections: OAuth connections and API credentials
+
+    Security: All queries are automatically filtered by the campaigner's agency.
+    The tool ONLY accepts SELECT queries - no INSERT, UPDATE, DELETE, or DDL.
+
+    Input should be a valid PostgreSQL SELECT query.
+    Output will be a JSON array of result rows.
+    """
+
+    campaigner_id: int = PydanticField(description="ID of the authenticated campaigner")
+
+    def _run(self, query: str) -> str:
+        """Execute a SQL query and return results.
+
+        Args:
+            query: SQL SELECT query to execute
+
+        Returns:
+            JSON string with query results or error message
+        """
+        try:
+            sql_validator = SQLValidator()  # Shared validator instance
+
+            # Validate query with LLM validator
+            is_valid, reason, validation_details = sql_validator.validate(query)
+
+            if not is_valid:
+                error_msg = f"Query validation failed: {reason}"
+                logger.warning(f"🚫 [PostgresTool] Blocked invalid query from campaigner {self.campaigner_id}: {reason}")
+                import json
+                return json.dumps({
+                    "success": False,
+                    "error": error_msg,
+                    "validation": validation_details
+                })
+
+            # Additional basic validation
+            if not self._is_read_only_query(query):
+                error_msg = "Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, or DDL operations."
+                logger.warning(f"🚫 [PostgresTool] Blocked non-SELECT query from campaigner {self.campaigner_id}")
+                import json
+                return json.dumps({"success": False, "error": error_msg})
+
+            # Use query as-is (LLM should have written it with proper security filtering)
+            secured_query = query
+
+            logger.info(f"🔍 [PostgresTool] Executing query for campaigner {self.campaigner_id}")
+            logger.debug(f"📝 [PostgresTool] Query: {secured_query[:200]}...")
+
+            # Execute query
+            with get_db_connection() as session:
+                result = session.execute(text(secured_query), {"campaigner_id": self.campaigner_id})
+                rows = result.fetchall()
+
+                # Convert to list of dicts
+                if rows:
+                    columns = result.keys()
+                    results = [dict(zip(columns, row)) for row in rows]
+                else:
+                    results = []
+
+                logger.info(f"✅ [PostgresTool] Query returned {len(results)} rows")
+
+                # Format as JSON
+                import json
+                return json.dumps({
+                    "success": True,
+                    "row_count": len(results),
+                    "data": results
+                }, default=str)  # default=str handles datetime serialization
+
+        except Exception as e:
+            logger.error(f"❌ [PostgresTool] Query failed: {str(e)}", exc_info=True)
+            import json
+            return json.dumps({
+                "success": False,
+                "error": str(e)
+            })
+
+    async def _arun(self, query: str) -> str:
+        """Async version - not implemented, falls back to sync."""
+        return self._run(query)
+
+    def _is_read_only_query(self, query: str) -> bool:
+        """Check if query is a SELECT statement.
+
+        Args:
+            query: SQL query string
+
+        Returns:
+            True if query is SELECT only, False otherwise
+        """
+        # Normalize query
+        normalized = query.strip().upper()
+
+        # Remove comments
+        normalized = re.sub(r'--.*$', '', normalized, flags=re.MULTILINE)
+        normalized = re.sub(r'/\*.*?\*/', '', normalized, flags=re.DOTALL)
+
+        # Check for dangerous keywords
+        dangerous_keywords = [
+            'INSERT', 'UPDATE', 'DELETE', 'DROP', 'CREATE', 'ALTER',
+            'TRUNCATE', 'GRANT', 'REVOKE', 'EXEC', 'EXECUTE',
+            'CALL', 'MERGE', 'REPLACE', 'LOCK', 'UNLOCK'
+        ]
+
+        for keyword in dangerous_keywords:
+            if re.search(r'\b' + keyword + r'\b', normalized):
+                return False
+
+        # Must start with SELECT (after whitespace/comments)
+        if not normalized.startswith('SELECT'):
+            return False
+
+        return True
+
+    def _inject_security_filter(self, query: str) -> str:
+        """Inject security filtering into the query.
+
+        This ensures the query only returns data for the campaigner's agency.
+
+        Args:
+            query: Original SQL query
+
+        Returns:
+            Modified query with security filter
+        """
+        # For now, we rely on the SQL writer to include proper JOINs
+        # In a more sophisticated implementation, we could parse and modify the SQL
+        # to automatically inject agency_id filtering
+
+        # TODO: Implement SQL parsing to automatically inject:
+        # JOIN campaigners camp ON camp.agency_id = <table>.agency_id
+        # WHERE camp.id = :campaigner_id
+
+        return query
+
+    def get_schema_info(self) -> Dict[str, Any]:
+        """Get database schema information dynamically from SQLModel classes.
+
+        Returns:
+            Dictionary with table schemas
+        """
+        schema_info = {}
+
+        # Map of models to extract schema from
+        models = {
+            "agencies": Agency,
+            "campaigners": Campaigner,
+            "customers": Customer,
+            "kpi_goals": KpiGoal,
+            "kpi_values": KpiValue,
+            "digital_assets": DigitalAsset,
+            "connections": Connection,
+            "rtm_table": RTMTable,
+            "questions_table": QuestionsTable,
+        }
+
+        for table_name, model_class in models.items():
+            schema_info[table_name] = self._extract_model_schema(model_class)
+
+        # Add relationship information
+        schema_info["relationships"] = {
+            "description": "Table relationships for proper JOINs",
+            "chains": {
+                "kpi_goals_to_campaigner": "kpi_goals.customer_id → customers.id → customers.agency_id = campaigners.agency_id → campaigners.id = :campaigner_id",
+                "kpi_values_to_campaigner": "kpi_values.customer_id → customers.id → customers.agency_id = campaigners.agency_id → campaigners.id = :campaigner_id",
+                "customers_to_campaigner": "customers.agency_id = campaigners.agency_id → campaigners.id = :campaigner_id",
+                "digital_assets_to_campaigner": "digital_assets.customer_id → customers.id → customers.agency_id = campaigners.agency_id → campaigners.id = :campaigner_id",
+                "connections_to_campaigner": "connections.customer_id → customers.id → customers.agency_id = campaigners.agency_id → campaigners.id = :campaigner_id"
+            }
+        }
+
+        return schema_info
+
+    def _extract_model_schema(self, model_class) -> Dict[str, Any]:
+        """Extract schema information from a SQLModel class.
+
+        Args:
+            model_class: SQLModel class to extract schema from
+
+        Returns:
+            Dictionary with table description and columns
+        """
+        schema = {
+            "description": model_class.__doc__.strip() if model_class.__doc__ else model_class.__name__,
+            "columns": {}
+        }
+
+        # Get field information from the model
+        if hasattr(model_class, '__fields__'):
+            for field_name, field_info in model_class.__fields__.items():
+                # Get field type
+                field_type = self._format_field_type(field_info.annotation)
+
+                # Get field description from Field() if available
+                description = ""
+                if hasattr(field_info, 'description') and field_info.description:
+                    description = field_info.description
+                elif hasattr(field_info, 'field_info') and hasattr(field_info.field_info, 'description'):
+                    description = field_info.field_info.description or ""
+
+                # Check if it's a foreign key
+                is_foreign_key = False
+                foreign_key_table = None
+                if hasattr(field_info, 'field_info'):
+                    field_metadata = field_info.field_info
+                    if hasattr(field_metadata, 'json_schema_extra'):
+                        extra = field_metadata.json_schema_extra or {}
+                        if 'foreign_key' in extra:
+                            is_foreign_key = True
+                            foreign_key_table = extra['foreign_key'].split('.')[0]
+
+                # Check if field is optional
+                is_optional = get_origin(field_info.annotation) is Optional or type(None) in get_args(field_info.annotation)
+
+                # Build column description
+                col_desc_parts = [field_type]
+                if description:
+                    col_desc_parts.append(f"- {description}")
+                if is_foreign_key and foreign_key_table:
+                    col_desc_parts.append(f"(FK to {foreign_key_table})")
+                elif field_name == "id":
+                    col_desc_parts.append("(Primary key)")
+                if is_optional:
+                    col_desc_parts.append("(Optional)")
+
+                schema["columns"][field_name] = " ".join(col_desc_parts)
+
+        # Add security information for tables that need JOINs
+        table_name = model_class.__tablename__ if hasattr(model_class, '__tablename__') else model_class.__name__.lower()
+
+        if table_name in ["kpi_goals", "kpi_values"]:
+            schema["security"] = f"MUST join: {table_name} → customers → campaigners"
+            schema["example_join"] = f"FROM {table_name} kg JOIN customers c ON c.id = kg.customer_id JOIN campaigners camp ON camp.agency_id = c.agency_id WHERE camp.id = :campaigner_id"
+        elif table_name == "customers":
+            schema["security"] = "Join with campaigners on agency_id"
+            schema["example_join"] = "FROM customers c JOIN campaigners camp ON camp.agency_id = c.agency_id WHERE camp.id = :campaigner_id"
+        elif table_name == "campaigners":
+            schema["security"] = "Auto-filtered by campaigner_id"
+        elif table_name in ["digital_assets", "connections"]:
+            schema["security"] = f"MUST join: {table_name} → customers → campaigners"
+            schema["example_join"] = f"FROM {table_name} da JOIN customers c ON c.id = da.customer_id JOIN campaigners camp ON camp.agency_id = c.agency_id WHERE camp.id = :campaigner_id"
+
+        return schema
+
+    def _format_field_type(self, annotation) -> str:
+        """Format a Python type annotation as a readable string.
+
+        Args:
+            annotation: Type annotation
+
+        Returns:
+            Human-readable type string
+        """
+        # Handle Optional types
+        origin = get_origin(annotation)
+        if origin is Optional:
+            args = get_args(annotation)
+            inner_type = args[0] if args else annotation
+            return self._format_field_type(inner_type)
+
+        # Handle basic types
+        if annotation == int or annotation == 'int':
+            return "int"
+        elif annotation == str or annotation == 'str':
+            return "str"
+        elif annotation == float or annotation == 'float':
+            return "float"
+        elif annotation == bool or annotation == 'bool':
+            return "bool"
+        elif hasattr(annotation, '__name__') and 'datetime' in annotation.__name__.lower():
+            return "datetime"
+        elif hasattr(annotation, '__name__') and 'dict' in annotation.__name__.lower():
+            return "dict/json"
+        elif hasattr(annotation, '__name__') and 'list' in annotation.__name__.lower():
+            return "list/array"
+        elif hasattr(annotation, '__name__'):
+            return annotation.__name__
+        else:
+            return str(annotation)

--- a/app/core/agents/tools/sql_validator.py
+++ b/app/core/agents/tools/sql_validator.py
@@ -1,0 +1,182 @@
+"""SQL query validator using LLM."""
+
+import logging
+import re
+from typing import Dict, Any, Tuple
+from langchain_core.messages import SystemMessage, HumanMessage
+# from langchain_openai import ChatOpenAI
+# from langchain_anthropic import ChatAnthropic
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_core.messages import HumanMessage
+from langchain_core.language_models import BaseChatModel
+
+logger = logging.getLogger(__name__)
+
+
+class SQLValidator:
+    """Validates SQL queries for safety and correctness using an LLM."""
+
+    def __init__(self, llm: BaseChatModel = None):
+        """Initialize the SQL validator.
+
+        Args:
+            llm: Language model for validation (defaults to gpt-4o-mini)
+        """
+        self.llm = llm or ChatGoogleGenerativeAI(model="gemini-2.5-flash") #ChatAnthropic(model='claude-3-opus-20240229') #ChatOpenAI(model="gpt-4o-mini", temperature=0)
+        self.system_prompt = """You are a strict SQL security validator.
+
+Your job is to analyze SQL queries and ensure they are:
+1. READ-ONLY (SELECT queries only)
+2. Properly secured with agency-level filtering
+3. Free from SQL injection vulnerabilities
+4. Syntactically correct PostgreSQL
+
+REQUIRED SECURITY PATTERN:
+Every query accessing customer/campaign data MUST include a JOIN to the campaigners table
+with filtering by :campaigner_id parameter.
+
+Valid patterns:
+1. For kpi_goals or kpi_values (via customers):
+```sql
+FROM kpi_goals kg
+JOIN customers c ON c.id = kg.customer_id
+JOIN campaigners camp ON camp.agency_id = c.agency_id
+WHERE camp.id = :campaigner_id
+```
+
+2. For customers table (direct):
+```sql
+FROM customers c
+JOIN campaigners camp ON camp.agency_id = c.agency_id
+WHERE camp.id = :campaigner_id
+```
+
+3. For agencies or campaigners table:
+```sql
+FROM campaigners WHERE id = :campaigner_id
+-- or --
+FROM agencies a JOIN campaigners c ON c.agency_id = a.id WHERE c.id = :campaigner_id
+```
+
+The key requirement is: WHERE clause MUST contain `camp.id = :campaigner_id` or equivalent.
+
+FORBIDDEN:
+- INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE
+- GRANT, REVOKE, EXEC, EXECUTE, CALL
+- Multiple statements (semicolons)
+- Comments that might hide malicious code
+- Dynamic SQL or string concatenation
+- Subqueries that bypass security filtering
+
+Respond with JSON:
+```json
+{
+  "valid": true|false,
+  "reason": "explanation of validation result",
+  "security_score": 0-100,
+  "suggestions": ["optional suggestions for improvement"]
+}
+```
+"""
+
+    def validate(self, query: str, context: Dict[str, Any] = None) -> Tuple[bool, str, Dict[str, Any]]:
+        """Validate a SQL query for safety and correctness.
+
+        Args:
+            query: SQL query string to validate
+            context: Additional context about the query
+
+        Returns:
+            Tuple of (is_valid, reason, validation_details)
+        """
+        logger.info("🔍 [SQLValidator] Validating query")
+        logger.debug(f"📝 [SQLValidator] Query: {query[:200]}...")
+
+        try:
+            # Quick pre-checks
+            if not self._basic_validation(query):
+                return False, "Failed basic validation checks", {"security_score": 0}
+
+            # LLM-based validation
+            messages = [
+                SystemMessage(content=self.system_prompt),
+                HumanMessage(content=f"""Validate this SQL query:
+
+```sql
+{query}
+```
+
+Context: Query will be executed with campaigner_id parameter for security filtering.
+""")
+            ]
+
+            response = self.llm.invoke(messages)
+            logger.debug(f"💭 [SQLValidator] LLM response: {response.content[:200]}...")
+
+            # Parse response
+            import json
+            # Extract JSON from markdown code blocks if present
+            content = response.content
+            if "```json" in content:
+                content = content.split("```json")[1].split("```")[0].strip()
+            elif "```" in content:
+                content = content.split("```")[1].split("```")[0].strip()
+
+            validation_result = json.loads(content)
+
+            is_valid = validation_result.get("valid", False)
+            reason = validation_result.get("reason", "No reason provided")
+
+            if is_valid:
+                logger.info(f"✅ [SQLValidator] Query validated successfully (score: {validation_result.get('security_score', 'N/A')})")
+            else:
+                logger.warning(f"🚫 [SQLValidator] Query rejected: {reason}")
+
+            return is_valid, reason, validation_result
+
+        except Exception as e:
+            logger.error(f"❌ [SQLValidator] Validation error: {str(e)}", exc_info=True)
+            return False, f"Validation failed: {str(e)}", {"security_score": 0}
+
+    def _basic_validation(self, query: str) -> bool:
+        """Perform basic regex-based validation.
+
+        Args:
+            query: SQL query string
+
+        Returns:
+            True if passes basic checks, False otherwise
+        """
+        if not query or not query.strip():
+            logger.warning("🚫 [SQLValidator] Empty query")
+            return False
+
+        normalized = query.strip().upper()
+
+        # Remove comments for analysis
+        normalized = re.sub(r'--.*$', '', normalized, flags=re.MULTILINE)
+        normalized = re.sub(r'/\*.*?\*/', '', normalized, flags=re.DOTALL)
+
+        # Must start with SELECT
+        if not normalized.startswith('SELECT'):
+            logger.warning("🚫 [SQLValidator] Query does not start with SELECT")
+            return False
+
+        # Check for dangerous keywords
+        dangerous_keywords = [
+            'INSERT', 'UPDATE', 'DELETE', 'DROP', 'CREATE', 'ALTER',
+            'TRUNCATE', 'GRANT', 'REVOKE', 'EXEC', 'EXECUTE',
+            'CALL', 'MERGE', 'REPLACE', 'LOCK', 'UNLOCK', 'SET '
+        ]
+
+        for keyword in dangerous_keywords:
+            if re.search(r'\b' + keyword + r'\b', normalized):
+                logger.warning(f"🚫 [SQLValidator] Dangerous keyword found: {keyword}")
+                return False
+
+        # Check for multiple statements
+        if ';' in query.rstrip(';'):  # Allow trailing semicolon
+            logger.warning("🚫 [SQLValidator] Multiple statements detected")
+            return False
+
+        return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,57 @@
-crewai
-crewai-tools
-fastapi
-uvicorn[standard]
-gunicorn
-python-dotenv
-sqlmodel
-psycopg2-binary
-alembic
-email-validator
+# Core frameworks
+langgraph
+langgraph-cli==0.1.55
+langgraph-cli[inmem]
+langgraph-checkpoint-sqlite==2.0.6
 langchain-google-genai
-pydantic-settings
+
+crewai==0.130.0
+crewai-tools
+
+# LangChain
+langchain==0.3.26
+langchain-community==0.3.26
+langchain-openai==0.2.14
+langchain-anthropic==0.3.9
+
+# MCP Integration
+mcp==1.1.2
+
+# Data validation and models
+pydantic==2.10.6
+pydantic-settings==2.7.1
+sqlmodel==0.0.22
+
+# Database
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.10
+alembic==1.14.0
+
+# Environment and configuration
+python-dotenv==1.0.0
+
+# API framework (future)
+fastapi==0.115.6
+uvicorn==0.34.0
+gunicorn
+
+# Utilities
+httpx==0.28.1
+tenacity==9.0.0
+
+# Testing
+pytest==8.3.4
+pytest-asyncio==0.25.2
+pytest-cov==6.0.0
+pytest-mock==3.14.0
+
+# Development
+black==24.10.0
+ruff==0.8.4
+mypy==1.14.0
+
+email-validator
+
 # Authentication dependencies
 python-jose[cryptography]
 python-multipart
@@ -24,8 +66,6 @@ google-analytics-admin
 google-auth-oauthlib
 cryptography
 
-# Google Ads dependencies
-google-ads
 
 # DialogCX dependencies - using REST API instead of heavy client library
 PyJWT[crypto]
@@ -33,6 +73,8 @@ PyJWT[crypto]
 # Admin interface dependencies
 httpx
 
+# Google Ads dependencies
+google-ads
 # Facebook dependencies
 facebook-sdk
 requests-oauthlib


### PR DESCRIPTION
Many updates, i know.
but they can be seen as follows:
1. api/v1/chat.py <- main rout for the chat with the new agents.
2. api/dependancies <- connecting between the chat router and the actual chat sessions.
3. main.py <- updates for the new route, plus added debug logs for visibility.
4. core/agents <- directory that contains the agents:
- crew : crewai agents (i know its duplicate with whats already in there but i want to make it cleaner so that we will remove the other later)
- database : db connection functions. will be removed later. as they are already implemented in the repo.
- graph : langgraph agents (replacing the dialogcx)
- mcp_clients : nothing really there. placeholder for future development
- tools : contains the agents tools (like postgres communicator).
5. added some schemes to "models" directory